### PR TITLE
Feature/add project start cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A web framework written in GO on-top of `echo` to ease your application developm
   - [Do’s and Don’ts](#dos-and-donts)
     - [Context](#context)
     - [Pointer](#pointer)
+  - [Template Development](#template-development)
+    - [Replacement Directive](#replacement-directive)
+    - [Template File For Hidden File](#template-file-for-hidden-file)
 
 ## How to use
 ### Initialize a project
@@ -87,26 +90,13 @@ For complicated object, pointer should be used as parameter instead of values to
 In `.go` file, you can wrap content with `/**#bean*/` and `/*#bean.replace(<Replacement>)**/`. Bean will replace the content with the replacement.
 for example, when content in template file is 
 ```text
-/**#bean*/"demo/framework/dbdrivers"/*#bean.replace("{{ .PkgPath }}/framework/dbdrivers")**/
+/**#bean*/
+"demo/framework/dbdrivers"
+/*#bean.replace("{{ .PkgPath }}/framework/dbdrivers")**/
 ```
 Bean will generate:
 ```text
 "{{ .PkgPath }}/framework/dbdrivers"
-```
-
-`/**#bean*/` should in the head of line. Because `go fmt` will reorder it.
-for example
-before `go fmt`
-```text
-ierror /**#bean*/ "demo/framework/internals/error" /*#bean.replace(ierror "{{ .PkgPath }}/framework/internals/error")**/
-```
-after `go fmt`
-```text
-ierror "demo/framework/internals/error" /**#bean*/  /*#bean.replace(ierror "{{ .PkgPath }}/framework/internals/error")**/
-```
-In this situation, you should write it:
-```text
-/**#bean*/ ierror "demo/framework/internals/error" /*#bean.replace(ierror "{{ .PkgPath }}/framework/internals/error")**/
 ```
 
 ### Template File For Hidden File

--- a/internal/project/cmd/root.go
+++ b/internal/project/cmd/root.go
@@ -1,0 +1,52 @@
+/**#bean*/ /*#bean.replace({{ .Copyright }})**/
+package cmd
+
+import (
+	"log"
+	"os"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "/**#bean*/ /*#bean.replace({{ .PkgName }})**/ command [args...]",
+	Short: "The CLI of /**#bean*/ /*#bean.replace({{ .PkgName }})**/",
+	Long: `The starting point of /**#bean*/ /*#bean.replace({{ .PkgName }})**/, contains some
+useful command like start...`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		rootCmd.Version = bi.Main.Version
+	} else {
+		log.Fatalln("Failed to read build info")
+	}
+
+	viper.AddConfigPath(".")
+	viper.SetConfigType("json")
+	viper.SetConfigName("env")
+
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/internal/project/cmd/start.go
+++ b/internal/project/cmd/start.go
@@ -4,7 +4,7 @@ package cmd
 import (
 	/**#bean*/
 	"demo/framework/bean"
-	/*#bean.replace(beanValidator "{{ .PkgPath }}/framework/bean")**/
+	/*#bean.replace("{{ .PkgPath }}/framework/bean")**/
 	/**#bean*/
 	beanValidator "demo/framework/internals/validator"
 	/*#bean.replace(beanValidator "{{ .PkgPath }}/framework/internals/validator")**/

--- a/internal/project/cmd/start.go
+++ b/internal/project/cmd/start.go
@@ -1,0 +1,81 @@
+/**#bean*/ /*#bean.replace({{ .Copyright }})**/
+package cmd
+
+import (
+	/**#bean*/
+	"demo/framework/bean"
+	/*#bean.replace(beanValidator "{{ .PkgPath }}/framework/bean")**/
+	/**#bean*/
+	beanValidator "demo/framework/internals/validator"
+	/*#bean.replace(beanValidator "{{ .PkgPath }}/framework/internals/validator")**/
+	/**#bean*/
+	"demo/routers"
+	/*#bean.replace("{{ .PkgPath }}/routers")**/
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	// Used for flags.
+	host string
+	port string
+
+	// startCmd represents the start command.
+	startCmd = &cobra.Command{
+		Use:   "start",
+		Short: "Start the web service",
+		Long:  `Start the web service base on the configs in env.json`,
+		Run:   start,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(startCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// startCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	defaultHost := viper.GetString("http.host")
+	defaultPort := viper.GetString("http.port")
+	startCmd.Flags().StringVar(&host, "host", defaultHost, "host address")
+	startCmd.Flags().StringVar(&port, "port", defaultPort, "port number")
+}
+
+func start(cmd *cobra.Command, args []string) {
+	b := new(bean.Bean)
+
+	b.InitDB()
+
+	b.BeforeBootstrap = func() {
+		// init global middleware if you need
+		// middlerwares.Init()
+
+		// init router
+		routers.Init()
+	}
+
+	// Below is an example of how you can initialize your own validator. Just create a new directory
+	// as `packages/validator` and create a validator package inside the directory. Then initialize your
+	// own validation function here, such as; `validator.MyTestValidationFunction(c, vd)`.
+	b.Validate = func(c echo.Context, vd *validator.Validate) {
+		beanValidator.TestUserIdValidation(c, vd)
+
+		// Add your own validation function here.
+	}
+
+	// Below is an example of how you can set custom error handler middleware
+	// bean can call `UseErrorHandlerMiddleware` multiple times
+	b.UseErrorHandlerMiddleware(func(e error, c echo.Context) (bool, error) {
+		return false, nil
+	})
+
+	b.ServeAt(host, port)
+}

--- a/internal/project/framework/bootstrap/kernel.go
+++ b/internal/project/framework/bootstrap/kernel.go
@@ -9,9 +9,6 @@ import (
 	"time"
 
 	/**#bean*/
-
-	/*#bean.replace("{{ .PkgPath }}/framework/dbdrivers")**/
-	/**#bean*/
 	"demo/framework/internals/binder"
 	/*#bean.replace("{{ .PkgPath }}/framework/internals/binder")**/
 	/**#bean*/

--- a/internal/project/framework/bootstrap/kernel.go
+++ b/internal/project/framework/bootstrap/kernel.go
@@ -4,13 +4,12 @@
 package bootstrap
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	/**#bean*/
-	"demo/framework/dbdrivers"
+
 	/*#bean.replace("{{ .PkgPath }}/framework/dbdrivers")**/
 	/**#bean*/
 	"demo/framework/internals/binder"
@@ -32,14 +31,11 @@ import (
 	/*#bean.replace("{{ .PkgPath }}/framework/internals/template")**/
 	"github.com/getsentry/sentry-go"
 	sentryecho "github.com/getsentry/sentry-go/echo"
-	"github.com/go-redis/redis/v8"
 	"github.com/labstack/echo-contrib/prometheus"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
 	"github.com/spf13/viper"
-	"go.mongodb.org/mongo-driver/mongo"
-	"gorm.io/gorm"
 )
 
 func New() *echo.Echo {
@@ -55,18 +51,8 @@ func New() *echo.Echo {
 	// Hide default `Echo` banner during startup.
 	e.HideBanner = true
 
-	// Set viper path and read configuration. You must keep `env.json` file in the root of your project.
-	viper.AddConfigPath(".")
-	viper.SetConfigType("json")
-	viper.SetConfigName("env")
-
-	err := viper.ReadInConfig()
-	if err != nil {
-		fmt.Printf("Configuration file error: %v Server 🚀  crash landed. Exiting...\n", err)
-
-		// Go does not use an integer return value from main to indicate exit status.
-		// To exit with a non-zero status we should use os.Exit.
-		os.Exit(1)
+	if err := viper.ReadInConfig(); err != nil {
+		log.Fatalf("Configuration file error: %v Server 🚀  crash landed. Exiting...\n", err)
 	}
 
 	// IMPORTANT: Time out middleware. It has to be the first middleware to initialize.
@@ -89,15 +75,13 @@ func New() *echo.Echo {
 		// IMPORTANT: Set log output into file (console.log) instead `stdout`.
 		if _, err := os.Stat(logFile); os.IsNotExist(err) {
 			if err := os.MkdirAll(filepath.Dir(logFile), 0754); err != nil {
-				fmt.Printf("Unable to create log file: %v Server 🚀  crash landed. Exiting...\n", err)
-				os.Exit(1)
+				log.Fatalf("Unable to create log file: %v Server 🚀  crash landed. Exiting...\n", err)
 			}
 		}
 
 		logfp, err := os.OpenFile(logFile, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0664)
 		if err != nil {
-			fmt.Printf("Unable to open log file: %v Server 🚀  crash landed. Exiting...\n", err)
-			os.Exit(1)
+			log.Printf("Unable to open log file: %v Server 🚀  crash landed. Exiting...\n", err)
 		}
 
 		e.Logger.SetOutput(logfp)
@@ -142,7 +126,6 @@ func New() *echo.Echo {
 		sentryDsn := viper.GetString("sentry.dsn")
 		if isValidSentryDSN := str.IsValidUrl(sentryDsn); !isValidSentryDSN {
 			e.Logger.Fatal("Sentry invalid DSN: ", sentryDsn, ". Server 🚀  crash landed. Exiting...")
-			os.Exit(1)
 		}
 
 		sentryAttachStacktrace := viper.GetBool("sentry.attachStacktrace")
@@ -155,17 +138,12 @@ func New() *echo.Echo {
 		}
 
 		// To initialize Sentry's handler, we need to initialize sentry first.
-		err := sentry.Init(sentry.ClientOptions{
+		if err := sentry.Init(sentry.ClientOptions{
 			Dsn:              sentryDsn,
 			AttachStacktrace: sentryAttachStacktrace,
 			TracesSampleRate: sentryapmTracesSampleRate,
-		})
-		if err != nil {
+		}); err != nil {
 			e.Logger.Fatal("Sentry initialization failed: ", err, ". Server 🚀  crash landed. Exiting...")
-
-			// Go does not use an integer return value from main to indicate exit status.
-			// To exit with a non-zero status we should use os.Exit.
-			os.Exit(1)
 		}
 
 		// Once it's done, let's attach the handler as one of our middleware.
@@ -223,53 +201,6 @@ func New() *echo.Echo {
 
 	// `/ping` uri to response a `pong`.
 	e.Use(imiddleware.Heartbeat())
-
-	// Initialize all database driver.
-	var masterMySQLDB *gorm.DB
-	var masterMySQLDBName string
-	var masterMongoDB *mongo.Client
-	var masterMongoDBName string
-	var masterRedisDB *redis.Client
-	var masterRedisDBName int
-
-	var tenantMySQLDBs map[uint64]*gorm.DB
-	var tenantMySQLDBNames map[uint64]string
-	var tenantMongoDBs map[uint64]*mongo.Client
-	var tenantMongoDBNames map[uint64]string
-	var tenantRedisDBs map[uint64]*redis.Client
-	var tenantRedisDBNames map[uint64]int
-
-	isTenant := viper.GetBool("database.mysql.isTenant")
-	if isTenant {
-		dbdrivers.InitTenantIdMutexMap()
-		masterMySQLDB, masterMySQLDBName = dbdrivers.InitMysqlMasterConn()
-		tenantMySQLDBs, tenantMySQLDBNames = dbdrivers.InitMysqlTenantConns(masterMySQLDB)
-		tenantMongoDBs, tenantMongoDBNames = dbdrivers.InitMongoTenantConns(masterMySQLDB)
-		tenantRedisDBs, tenantRedisDBNames = dbdrivers.InitRedisTenantConns(masterMySQLDB)
-
-	} else {
-		masterMySQLDB, masterMySQLDBName = dbdrivers.InitMysqlMasterConn()
-		masterMongoDB, masterMongoDBName = dbdrivers.InitMongoMasterConn()
-		masterRedisDB, masterRedisDBName = dbdrivers.InitRedisMasterConn()
-	}
-
-	masterBadgerDB := dbdrivers.InitBadgerConn(e)
-
-	global.DBConn = &global.DBDeps{
-		MasterMySQLDB:      masterMySQLDB,
-		MasterMySQLDBName:  masterMySQLDBName,
-		TenantMySQLDBs:     tenantMySQLDBs,
-		TenantMySQLDBNames: tenantMySQLDBNames,
-		MasterMongoDB:      masterMongoDB,
-		MasterMongoDBName:  masterMongoDBName,
-		TenantMongoDBs:     tenantMongoDBs,
-		TenantMongoDBNames: tenantMongoDBNames,
-		MasterRedisDB:      masterRedisDB,
-		MasterRedisDBName:  masterRedisDBName,
-		TenantRedisDBs:     tenantRedisDBs,
-		TenantRedisDBNames: tenantRedisDBNames,
-		BadgerDB:           masterBadgerDB,
-	}
 
 	// Set custom request binder
 	e.Binder = &binder.CustomBinder{}

--- a/internal/project/framework/dbdrivers/badger.go
+++ b/internal/project/framework/dbdrivers/badger.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/dgraph-io/badger/v3"
-	"github.com/labstack/echo/v4"
 	"github.com/spf13/viper"
 )
 
@@ -20,12 +19,12 @@ var badgerConn *badger.DB
 var badgerOnce sync.Once
 
 // Initialize the Badger database.
-func InitBadgerConn(e *echo.Echo) *badger.DB {
-	return connectBadgerDB(e)
+func InitBadgerConn() *badger.DB {
+	return connectBadgerDB()
 }
 
 // connectBadgerDB returns the singleton badger connection
-func connectBadgerDB(e *echo.Echo) *badger.DB {
+func connectBadgerDB() *badger.DB {
 
 	badgerOnce.Do(func() {
 
@@ -51,8 +50,6 @@ func connectBadgerDB(e *echo.Echo) *badger.DB {
 
 		badgerConn, err = badger.Open(opt)
 		if err != nil {
-			e.Logger.Error(err)
-			// Panic will be captured by `sentry` in staging and production.
 			panic(err)
 		}
 	})

--- a/internal/project/framework/internals/helpers/common.go
+++ b/internal/project/framework/internals/helpers/common.go
@@ -126,7 +126,7 @@ func GetContextInstanceEnvironmentAndConfig() (*echo.Echo, echo.Context, string)
 		masterRedisDB, masterRedisDBName = dbdrivers.InitRedisMasterConn()
 	}
 
-	masterBadgerDB := dbdrivers.InitBadgerConn(e)
+	masterBadgerDB := dbdrivers.InitBadgerConn()
 
 	global.DBConn = &global.DBDeps{
 		MasterMySQLDB:      masterMySQLDB,

--- a/internal/project/main.go
+++ b/internal/project/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	/**#bean*/
 	"demo/cmd"
-	/*#bean.replace({{ .PkgName }}/cmd)**/)
+	/*#bean.replace("{{ .PkgName }}/cmd")**/)
 
 func main() {
 	cmd.Execute()

--- a/internal/project/main.go
+++ b/internal/project/main.go
@@ -3,45 +3,9 @@ package main
 
 import (
 	/**#bean*/
-	"demo/framework"
-	/*#bean.replace("{{ .PkgPath }}/framework")**/
-	/**#bean*/
-	beanValidator "demo/framework/internals/validator"
-	/*#bean.replace(beanValidator "{{ .PkgPath }}/framework/internals/validator")**/
-	/**#bean*/
-	"demo/routers"
-	/*#bean.replace("{{ .PkgPath }}/routers")**/
-
-	"github.com/go-playground/validator/v10"
-	"github.com/labstack/echo/v4"
-)
+	"demo/cmd"
+	/*#bean.replace({{ .PkgName }}/cmd)**/)
 
 func main() {
-
-	bean := new(framework.Bean)
-
-	bean.BeforeBootstrap = func() {
-		// init global middleware if you need
-		// middlerwares.Init()
-
-		// init router
-		routers.Init()
-	}
-
-	// Below is an example of how you can initialize your own validator. Just create a new directory
-	// as `packages/validator` and create a validator package inside the directory. Then initialize your
-	// own validation function here, such as; `validator.MyTestValidationFunction(c, vd)`.
-	bean.Validate = func(c echo.Context, vd *validator.Validate) {
-		beanValidator.TestUserIdValidation(c, vd)
-
-		// Add your own validation function here.
-	}
-
-	// Below is an example of how you can set custom error handler middleware
-	// bean can call `UseErrorHandlerMiddleware` multiple times
-	bean.UseErrorHandlerMiddleware(func(e error, c echo.Context) (bool, error) {
-		return false, nil
-	})
-
-	bean.Bootstrap()
+	cmd.Execute()
 }


### PR DESCRIPTION
- moved the startup process into start cmd
- added extra host & port flags for start cmd (default values are reading from env.json)
- removed the echo dependency in badger
- renamed the `bean.boostroop()` -> `bean.ServeAt()`
- moved the `initDB()` into bean package
- updated readme

`root` cmd
<img width="547" alt="Screen Shot 2022-01-12 at 14 55 58" src="https://user-images.githubusercontent.com/77815791/149072040-9b9dd18b-6284-4578-92e6-8f434c50a1d1.png">

`start` cmd
<img width="452" alt="Screen Shot 2022-01-12 at 14 56 07" src="https://user-images.githubusercontent.com/77815791/149072070-8a7fec0b-cb0a-40a4-9dbc-2f698fe11e8d.png">

note: the global package still sticking with many other pacakge, mainly using for logging purpose,
need to find a better way to remove these dependency.