### PR TITLE
add nil-block for error handling

### DIFF
--- a/error/api_error.go
+++ b/error/api_error.go
@@ -65,5 +65,8 @@ func (e *APIError) String() string {
 // This function need to be call explicitly because the APIError embedded the *stacktrace.Stack which already implemented the Format()
 // function and treat it as a formatter. Example: fmt.Println(e.String())
 func (e *APIError) Error() string {
-	return e.Err.Error()
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "No error detail available"
 }

--- a/error/error_handler.go
+++ b/error/error_handler.go
@@ -24,6 +24,7 @@ package error
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -59,6 +60,8 @@ func APIErrorHanderFunc(e error, c echo.Context) (bool, error) {
 	if !ok {
 		return false, nil
 	}
+	log.Printf("he: %#v\n", he)
+	log.Printf("he.Err == nil: %#v\n", he.Err == nil)
 
 	if he.HTTPStatusCode >= 404 {
 		c.Logger().Error(he.Error())

--- a/error/error_handler.go
+++ b/error/error_handler.go
@@ -24,7 +24,6 @@ package error
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -60,8 +59,6 @@ func APIErrorHanderFunc(e error, c echo.Context) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	log.Printf("he: %#v\n", he)
-	log.Printf("he.Err == nil: %#v\n", he.Err == nil)
 
 	if he.HTTPStatusCode >= 404 {
 		c.Logger().Error(he.Error())


### PR DESCRIPTION
CMIIW. I made this PR because I get a nil pointer dereference panic error at runtime when I pass `nil` to `error.NewAPIError` or `error.NewIgnorableAPIError` as its third argument which of type is `error`.