### PR TITLE
Support Master Redis Built-In Operations

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,12 +9,12 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version: '1.20' # Make sure to specify the current version of Go the project is using
 
     - name: Lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOPATH=$(shell go env GOPATH)
-# v1.47.3 is the latest version of golangci-lint project based on Go 1.18
+# v1.55.2 is the latest version of golangci-lint project based on Go 1.20
 # change it according to the Go version this project is using
-GOLANGCI_LINT_VERSION=v1.47.3
+GOLANGCI_LINT_VERSION=v1.55.2
 
 all: lint test build
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ install: ## install the binary to $GOPATH/bin
 lint: ## run all the lint tools, install golangci-lint if not exist
 ifeq (,$(wildcard $(GOPATH)/bin/golangci-lint))
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) > /dev/null
-	$(GOPATH)/bin/golangci-lint run || exit 0
+	$(GOPATH)/bin/golangci-lint run
 else
-	$(GOPATH)/bin/golangci-lint run || exit 0
+	$(GOPATH)/bin/golangci-lint run
 endif
 
 test: ## run tests with race detactor

--- a/cmd/bean/internal/_tpl/handler.go
+++ b/cmd/bean/internal/_tpl/handler.go
@@ -55,7 +55,7 @@ func (handler *{{.HandlerNameLower}}Handler) {{.HandlerNameUpper}}JSONResponse(c
 		defer asyncFinish()
 
 		// example function that you want to execute asynchronously.
-		files, err := ioutil.ReadDir("./")
+		files, err := os.ReadDir("./")
 		for _, f := range files {
             fmt.Println(f.Name())
 		}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -24,8 +24,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -111,7 +111,7 @@ func command(cmd *cobra.Command, args []string) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	fileData, err := ioutil.ReadAll(file)
+	fileData, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -24,8 +24,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -105,7 +105,7 @@ func docker(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fileData, err := ioutil.ReadAll(file)
+	fileData, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -160,7 +160,7 @@ func docker(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fileData, err = ioutil.ReadAll(file)
+	fileData, err = io.ReadAll(file)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -26,8 +26,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -125,7 +125,7 @@ func handler(cmd *cobra.Command, args []string) {
 
 	defer file.Close()
 
-	fileData, err := ioutil.ReadAll(file)
+	fileData, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -273,7 +273,7 @@ func insertStringToNthLineOfFile(filePath, textToInsert string, lineNumber int) 
 		fileContent += "\n"
 	}
 
-	return ioutil.WriteFile(filePath, []byte(fileContent), 0644)
+	return os.WriteFile(filePath, []byte(fileContent), 0644)
 }
 
 // Replace sting to n-th line of file.
@@ -304,12 +304,12 @@ func replaceStringToNthLineOfFile(filePath, newText string, lineNumber int) erro
 		}
 	}
 
-	return ioutil.WriteFile(filePath, []byte(fileContent), 0644)
+	return os.WriteFile(filePath, []byte(fileContent), 0644)
 }
 
 func replaceStringFromFileByRegex(filePath, regex, additonal, replaceWith string) error {
 
-	input, err := ioutil.ReadFile(filePath)
+	input, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func replaceStringFromFileByRegex(filePath, regex, additonal, replaceWith string
 		replaceMe := additonal + match[1]
 		output := bytes.Replace(input, []byte(replaceMe), []byte(replaceWith), -1)
 
-		if err = ioutil.WriteFile(filePath, output, 0664); err != nil {
+		if err = os.WriteFile(filePath, output, 0664); err != nil {
 			return err
 		}
 	}
@@ -329,13 +329,13 @@ func replaceStringFromFileByRegex(filePath, regex, additonal, replaceWith string
 }
 
 func replaceStringFromFileByExactMatches(filePath, replaceMe, replaceWith string) error {
-	input, err := ioutil.ReadFile(filePath)
+	input, err := os.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
 
 	output := bytes.Replace(input, []byte(replaceMe), []byte(replaceWith), -1)
-	if err = ioutil.WriteFile(filePath, output, 0664); err != nil {
+	if err = os.WriteFile(filePath, output, 0664); err != nil {
 		return err
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,8 +24,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	fpath "path"
@@ -187,12 +187,12 @@ func (p *Project) generateProjectFiles(path string, d fs.DirEntry, err error) er
 				return err
 			}
 
-			content, err := ioutil.ReadAll(file)
+			content, err := io.ReadAll(file)
 			if err != nil {
 				return err
 			}
 
-			err = ioutil.WriteFile(p.RootDir+"/"+path, content, 0664)
+			err = os.WriteFile(p.RootDir+"/"+path, content, 0664)
 			if err != nil {
 				return err
 			}

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -25,8 +25,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -114,7 +114,7 @@ func repo(cmd *cobra.Command, args []string) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	fileData, err := ioutil.ReadAll(file)
+	fileData, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -25,8 +25,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 	"text/template"
@@ -141,7 +141,7 @@ func service(cmd *cobra.Command, args []string) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	fileData, err := ioutil.ReadAll(file)
+	fileData, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/goview/view.go
+++ b/goview/view.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -251,7 +250,7 @@ func DefaultFileHandler() FileHandler {
 			return "", fmt.Errorf("ViewEngine path:%v error: %v", path, err)
 		}
 
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("ViewEngine render read name:%v, path:%v, error: %v", tplFile, path, err)
 		}

--- a/helpers/escape.go
+++ b/helpers/escape.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"html"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -85,7 +84,7 @@ func PostDataStripTags(c echo.Context, trimSpace bool) (map[string]interface{}, 
 			}
 
 			// Restore the io.ReadCloser to its original state so that we can read c.Request().Body somewhere else
-			c.Request().Body = ioutil.NopCloser(bodyBytes)
+			c.Request().Body = io.NopCloser(bodyBytes)
 
 		} else {
 
@@ -145,7 +144,7 @@ func InterfaceStripTags(data interface{}, trimSpace bool) interface{} {
 // 		Age: 40,
 // 	}
 
-// 	helpers.StructStripTags(&test, true)
+// helpers.StructStripTags(&test, true)
 func StructStripTags(data interface{}, trimSpace bool) error {
 
 	bytes, err := json.Marshal(data)

--- a/internal/binder/bind.go
+++ b/internal/binder/bind.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -66,7 +65,7 @@ func (cb *CustomBinder) Bind(i interface{}, c echo.Context) (err error) {
 		}
 
 		// Restore the io.ReadCloser to its original state so that we can read c.Request().Body somewhere else.
-		c.Request().Body = ioutil.NopCloser(bodyBytes)
+		c.Request().Body = io.NopCloser(bodyBytes)
 
 		data, _ := helpers.PostDataStripTags(c, false)
 

--- a/internal/dbdrivers/redis.go
+++ b/internal/dbdrivers/redis.go
@@ -126,7 +126,7 @@ func InitRedisMasterConn(config RedisConfig) *RedisDBConn {
 	return masterRedisDB
 }
 
-func (clients *RedisDBConn) IsKeyExists(c context.Context, key string) (bool, error) {
+func (clients *RedisDBConn) KeyExists(c context.Context, key string) (bool, error) {
 	result, err := clients.Primary.Exists(c, key).Result()
 	if err != nil {
 		return false, errors.WithStack(err)
@@ -509,6 +509,10 @@ func (clients *RedisDBConn) ExpireKey(c context.Context, key string, ttl time.Du
 	}
 
 	return nil
+}
+
+func (clients *RedisDBConn) Pipelined(c context.Context, fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	return clients.Primary.Pipelined(c, fn)
 }
 
 // MSet This is a replacement of the original `MSet` method by utilizing the `pipeline` approach when Redis is in `cluster` mode.

--- a/internal/dbdrivers/redis.go
+++ b/internal/dbdrivers/redis.go
@@ -76,9 +76,9 @@ type FieldValuePair struct {
 
 var cachePrefix string
 
-func InitRedisTenantConns(config RedisConfig, master *gorm.DB, tenantAlterDbHostParam, tenantDBPassPhraseKey string) map[uint64]*RedisDBConn {
+func InitRedisTenantConns(config RedisConfig, masterMySQL *gorm.DB, tenantAlterDbHostParam, tenantDBPassPhraseKey string) map[uint64]*RedisDBConn {
 	cachePrefix = config.Prefix
-	tenantCfgs := GetAllTenantCfgs(master)
+	tenantCfgs := GetAllTenantCfgs(masterMySQL)
 
 	if len(tenantCfgs) > 0 {
 		return getAllRedisTenantDB(config, tenantCfgs, tenantAlterDbHostParam, tenantDBPassPhraseKey)
@@ -630,7 +630,7 @@ func getAllRedisTenantDB(config RedisConfig, tenantCfgs []*TenantConnections, te
 		if redisCfg, ok := cfgsMap["redis"]; ok {
 			password := redisCfg["password"].(string)
 
-			// IMPORTANT: If tenant database password is encrypted in master db config.
+			// IMPORTANT: If tenant database password is encrypted in master mysql db config.
 			if tenantDBPassPhraseKey != "" {
 				password, err = aes.BeanAESDecrypt(tenantDBPassPhraseKey, password)
 				if err != nil {

--- a/internal/middleware/access_log.go
+++ b/internal/middleware/access_log.go
@@ -27,7 +27,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -160,9 +159,9 @@ func AccessLoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 			// IMPORTANT: Get a copy of the request body for body dumper.
 			reqBody := []byte{}
 			if c.Request().Body != nil { // Read
-				reqBody, _ = ioutil.ReadAll(c.Request().Body)
+				reqBody, _ = io.ReadAll(c.Request().Body)
 			}
-			c.Request().Body = ioutil.NopCloser(bytes.NewBuffer(reqBody)) // Reset
+			c.Request().Body = io.NopCloser(bytes.NewBuffer(reqBody)) // Reset
 
 			// IMPORTANT: Create a multiWriter writes to both response
 			// and the local body dumper buffer. (`resBody` variable below)

--- a/store/redis/master.go
+++ b/store/redis/master.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/retail-ai-inc/bean/v2"
 	"github.com/retail-ai-inc/bean/v2/internal/dbdrivers"
 )
 
@@ -59,18 +58,19 @@ type masterCache struct {
 }
 
 // NewMasterCache creates a new MasterCache.
-// This assumes it is called after the (*Bean).InitDB() func.
-func NewMasterCache(dbDeps bean.DBDeps) MasterCache {
+// This assumes it is called after the (*Bean).InitDB() func and takes (bean.DBDeps).MasterRedisDB as input.
+func NewMasterCache(master *dbdrivers.RedisDBConn, prefix string) MasterCache {
 
-	if dbDeps.MasterRedisDB == nil {
-		bean.Logger().Error("master redis db is not initialized properly")
+	if master == nil {
+		panic("master redis db is not initialized properly")
 	}
 
 	return &masterCache{
-		&tenantCache{
+		cache: &tenantCache{
 			clients: map[uint64]*dbdrivers.RedisDBConn{
-				masterID: dbDeps.MasterRedisDB,
+				masterID: master,
 			},
+			prefix: prefix,
 		},
 	}
 }

--- a/store/redis/master.go
+++ b/store/redis/master.go
@@ -1,0 +1,144 @@
+// MIT License
+
+// Copyright (c) The RAI Authors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package redis
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/retail-ai-inc/bean/v2"
+	"github.com/retail-ai-inc/bean/v2/internal/dbdrivers"
+)
+
+const masterID uint64 = 0
+
+// MasterCache provides functions for master redis db.
+type MasterCache interface {
+	GetJSON(c context.Context, key string, dst interface{}) (bool, error)
+	GetString(c context.Context, companyID, subsidiaryID uint64, key string) (string, error)
+	MGet(c context.Context, companyID, subsidiaryID uint64, keys ...string) ([]interface{}, error)
+	HGet(c context.Context, companyID, subsidiaryID uint64, key string, field string) (string, error)
+	LRange(c context.Context, companyID, subsidiaryID uint64, key string, start, stop int64) ([]string, error)
+	SMembers(c context.Context, companyID, subsidiaryID uint64, key string) ([]string, error)
+	SIsMember(c context.Context, companyID, subsidiaryID uint64, key string, element interface{}) (bool, error)
+	SetJSON(c context.Context, companyID, subsidiaryID uint64, key string, data interface{}, ttl time.Duration) error
+	SetString(c context.Context, companyID, subsidiaryID uint64, key string, data string, ttl time.Duration) error
+	HSet(c context.Context, companyID, subsidiaryID uint64, key string, field string, data interface{}, ttl time.Duration) error
+	RPush(c context.Context, companyID, subsidiaryID uint64, key string, valueList []string) error
+	IncrementValue(c context.Context, companyID, subsidiaryID uint64, key string) error
+	SAdd(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error
+	SRem(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error
+	DelKey(c context.Context, companyID, subsidiaryID uint64, keys ...string) error
+	Expire(c context.Context, companyID, subsidiaryID uint64, key string, ttl time.Duration) error
+	Pipelined(c context.Context, fn func(redis.Pipeliner) error) ([]redis.Cmder, error)
+}
+
+type masterCache struct {
+	cache TenantCache
+}
+
+// NewMasterCache creates a new MasterCache.
+// This assumes it is called after the (*Bean).InitDB() func.
+func NewMasterCache(dbDeps bean.DBDeps) MasterCache {
+
+	if dbDeps.MasterRedisDB == nil {
+		bean.Logger().Error("master redis db is not initialized properly")
+	}
+
+	return &masterCache{
+		&tenantCache{
+			clients: map[uint64]*dbdrivers.RedisDBConn{
+				masterID: dbDeps.MasterRedisDB,
+			},
+		},
+	}
+}
+
+func (m *masterCache) GetJSON(c context.Context, key string, dst interface{}) (bool, error) {
+	return m.cache.GetJSON(c, masterID, key, dst)
+}
+
+func (m *masterCache) GetString(c context.Context, companyID, subsidiaryID uint64, key string) (string, error) {
+	return m.cache.GetString(c, masterID, key)
+}
+
+func (m *masterCache) MGet(c context.Context, companyID, subsidiaryID uint64, keys ...string) ([]interface{}, error) {
+	return m.cache.MGet(c, masterID, keys...)
+}
+
+func (m *masterCache) HGet(c context.Context, companyID, subsidiaryID uint64, key string, field string) (string, error) {
+	return m.cache.HGet(c, masterID, key, field)
+}
+
+func (m *masterCache) LRange(c context.Context, companyID, subsidiaryID uint64, key string, start, stop int64) ([]string, error) {
+	return m.cache.LRange(c, masterID, key, start, stop)
+}
+
+func (m *masterCache) SMembers(c context.Context, companyID, subsidiaryID uint64, key string) ([]string, error) {
+	return m.cache.SMembers(c, masterID, key)
+}
+
+func (m *masterCache) SIsMember(c context.Context, companyID, subsidiaryID uint64, key string, element interface{}) (bool, error) {
+	return m.cache.SIsMember(c, masterID, key, element)
+}
+
+func (m *masterCache) SetJSON(c context.Context, companyID, subsidiaryID uint64, key string, data interface{}, ttl time.Duration) error {
+	return m.cache.SetJSON(c, masterID, key, data, ttl)
+}
+
+func (m *masterCache) SetString(c context.Context, companyID, subsidiaryID uint64, key string, data string, ttl time.Duration) error {
+	return m.cache.SetString(c, masterID, key, data, ttl)
+}
+
+func (m *masterCache) HSet(c context.Context, companyID, subsidiaryID uint64, key string, field string, data interface{}, ttl time.Duration) error {
+	return m.cache.HSet(c, masterID, key, field, data, ttl)
+}
+
+func (m *masterCache) RPush(c context.Context, companyID, subsidiaryID uint64, key string, valueList []string) error {
+	return m.cache.RPush(c, masterID, key, valueList)
+}
+
+func (m *masterCache) IncrementValue(c context.Context, companyID, subsidiaryID uint64, key string) error {
+	return m.cache.IncrementValue(c, masterID, key)
+}
+
+func (m *masterCache) SAdd(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error {
+	return m.cache.SAdd(c, masterID, key, elements)
+}
+
+func (m *masterCache) SRem(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error {
+	return m.cache.SRem(c, masterID, key, elements)
+}
+
+func (m *masterCache) DelKey(c context.Context, companyID, subsidiaryID uint64, keys ...string) error {
+	return m.cache.DelKey(c, masterID, keys...)
+}
+
+func (m *masterCache) Expire(c context.Context, companyID, subsidiaryID uint64, key string, ttl time.Duration) error {
+	return m.cache.Expire(c, masterID, key, ttl)
+}
+
+func (m *masterCache) Pipelined(c context.Context, fn func(redis.Pipeliner) error) ([]redis.Cmder, error) {
+	return m.cache.Pipelined(c, masterID, fn)
+}

--- a/store/redis/master.go
+++ b/store/redis/master.go
@@ -35,21 +35,21 @@ const masterID uint64 = 0
 // MasterCache provides functions for master redis db.
 type MasterCache interface {
 	GetJSON(c context.Context, key string, dst interface{}) (bool, error)
-	GetString(c context.Context, companyID, subsidiaryID uint64, key string) (string, error)
-	MGet(c context.Context, companyID, subsidiaryID uint64, keys ...string) ([]interface{}, error)
-	HGet(c context.Context, companyID, subsidiaryID uint64, key string, field string) (string, error)
-	LRange(c context.Context, companyID, subsidiaryID uint64, key string, start, stop int64) ([]string, error)
-	SMembers(c context.Context, companyID, subsidiaryID uint64, key string) ([]string, error)
-	SIsMember(c context.Context, companyID, subsidiaryID uint64, key string, element interface{}) (bool, error)
-	SetJSON(c context.Context, companyID, subsidiaryID uint64, key string, data interface{}, ttl time.Duration) error
-	SetString(c context.Context, companyID, subsidiaryID uint64, key string, data string, ttl time.Duration) error
-	HSet(c context.Context, companyID, subsidiaryID uint64, key string, field string, data interface{}, ttl time.Duration) error
-	RPush(c context.Context, companyID, subsidiaryID uint64, key string, valueList []string) error
-	IncrementValue(c context.Context, companyID, subsidiaryID uint64, key string) error
-	SAdd(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error
-	SRem(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error
-	DelKey(c context.Context, companyID, subsidiaryID uint64, keys ...string) error
-	Expire(c context.Context, companyID, subsidiaryID uint64, key string, ttl time.Duration) error
+	GetString(c context.Context, key string) (string, error)
+	MGet(c context.Context, keys ...string) ([]interface{}, error)
+	HGet(c context.Context, key string, field string) (string, error)
+	LRange(c context.Context, key string, start, stop int64) ([]string, error)
+	SMembers(c context.Context, key string) ([]string, error)
+	SIsMember(c context.Context, key string, element interface{}) (bool, error)
+	SetJSON(c context.Context, key string, data interface{}, ttl time.Duration) error
+	SetString(c context.Context, key string, data string, ttl time.Duration) error
+	HSet(c context.Context, key string, field string, data interface{}, ttl time.Duration) error
+	RPush(c context.Context, key string, valueList []string) error
+	IncrementValue(c context.Context, key string) error
+	SAdd(c context.Context, key string, elements interface{}) error
+	SRem(c context.Context, key string, elements interface{}) error
+	DelKey(c context.Context, keys ...string) error
+	Expire(c context.Context, key string, ttl time.Duration) error
 	Pipelined(c context.Context, fn func(redis.Pipeliner) error) ([]redis.Cmder, error)
 }
 
@@ -79,63 +79,63 @@ func (m *masterCache) GetJSON(c context.Context, key string, dst interface{}) (b
 	return m.cache.GetJSON(c, masterID, key, dst)
 }
 
-func (m *masterCache) GetString(c context.Context, companyID, subsidiaryID uint64, key string) (string, error) {
+func (m *masterCache) GetString(c context.Context, key string) (string, error) {
 	return m.cache.GetString(c, masterID, key)
 }
 
-func (m *masterCache) MGet(c context.Context, companyID, subsidiaryID uint64, keys ...string) ([]interface{}, error) {
+func (m *masterCache) MGet(c context.Context, keys ...string) ([]interface{}, error) {
 	return m.cache.MGet(c, masterID, keys...)
 }
 
-func (m *masterCache) HGet(c context.Context, companyID, subsidiaryID uint64, key string, field string) (string, error) {
+func (m *masterCache) HGet(c context.Context, key string, field string) (string, error) {
 	return m.cache.HGet(c, masterID, key, field)
 }
 
-func (m *masterCache) LRange(c context.Context, companyID, subsidiaryID uint64, key string, start, stop int64) ([]string, error) {
+func (m *masterCache) LRange(c context.Context, key string, start, stop int64) ([]string, error) {
 	return m.cache.LRange(c, masterID, key, start, stop)
 }
 
-func (m *masterCache) SMembers(c context.Context, companyID, subsidiaryID uint64, key string) ([]string, error) {
+func (m *masterCache) SMembers(c context.Context, key string) ([]string, error) {
 	return m.cache.SMembers(c, masterID, key)
 }
 
-func (m *masterCache) SIsMember(c context.Context, companyID, subsidiaryID uint64, key string, element interface{}) (bool, error) {
+func (m *masterCache) SIsMember(c context.Context, key string, element interface{}) (bool, error) {
 	return m.cache.SIsMember(c, masterID, key, element)
 }
 
-func (m *masterCache) SetJSON(c context.Context, companyID, subsidiaryID uint64, key string, data interface{}, ttl time.Duration) error {
+func (m *masterCache) SetJSON(c context.Context, key string, data interface{}, ttl time.Duration) error {
 	return m.cache.SetJSON(c, masterID, key, data, ttl)
 }
 
-func (m *masterCache) SetString(c context.Context, companyID, subsidiaryID uint64, key string, data string, ttl time.Duration) error {
+func (m *masterCache) SetString(c context.Context, key string, data string, ttl time.Duration) error {
 	return m.cache.SetString(c, masterID, key, data, ttl)
 }
 
-func (m *masterCache) HSet(c context.Context, companyID, subsidiaryID uint64, key string, field string, data interface{}, ttl time.Duration) error {
+func (m *masterCache) HSet(c context.Context, key string, field string, data interface{}, ttl time.Duration) error {
 	return m.cache.HSet(c, masterID, key, field, data, ttl)
 }
 
-func (m *masterCache) RPush(c context.Context, companyID, subsidiaryID uint64, key string, valueList []string) error {
+func (m *masterCache) RPush(c context.Context, key string, valueList []string) error {
 	return m.cache.RPush(c, masterID, key, valueList)
 }
 
-func (m *masterCache) IncrementValue(c context.Context, companyID, subsidiaryID uint64, key string) error {
+func (m *masterCache) IncrementValue(c context.Context, key string) error {
 	return m.cache.IncrementValue(c, masterID, key)
 }
 
-func (m *masterCache) SAdd(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error {
+func (m *masterCache) SAdd(c context.Context, key string, elements interface{}) error {
 	return m.cache.SAdd(c, masterID, key, elements)
 }
 
-func (m *masterCache) SRem(c context.Context, companyID, subsidiaryID uint64, key string, elements interface{}) error {
+func (m *masterCache) SRem(c context.Context, key string, elements interface{}) error {
 	return m.cache.SRem(c, masterID, key, elements)
 }
 
-func (m *masterCache) DelKey(c context.Context, companyID, subsidiaryID uint64, keys ...string) error {
+func (m *masterCache) DelKey(c context.Context, keys ...string) error {
 	return m.cache.DelKey(c, masterID, keys...)
 }
 
-func (m *masterCache) Expire(c context.Context, companyID, subsidiaryID uint64, key string, ttl time.Duration) error {
+func (m *masterCache) Expire(c context.Context, key string, ttl time.Duration) error {
 	return m.cache.Expire(c, masterID, key, ttl)
 }
 

--- a/store/redis/tenant.go
+++ b/store/redis/tenant.go
@@ -226,12 +226,10 @@ func (t *tenantCache) MSetJSON(c context.Context, tenantID uint64, keys []string
 	if ln != len(data) {
 		return errors.New("key and data length mismatch")
 	}
-	for i, key := range keys {
-		keys[i] = t.prefix + "_" + key
-	}
-	var values = make([]interface{}, 0, ln*2)
-	for i, datum := range data {
-		values = append(values, keys[i], datum)
+	values := make([]interface{}, 0, ln*2)
+	for i := range keys {
+		pk := t.prefix + "_" + keys[i]
+		values = append(values, pk, data[i])
 	}
 
 	err := t.clients[tenantID].MSetWithTTL(c, ttl, values)


### PR DESCRIPTION
- Support Master Redis Built-In Operations as `MasterCache` in `store/redis/master.go`
  - ~~Remove pre-feature for cache prefix in all redis operations~~
  - Add a few funcs to `TenantCache` in `store/redis/tenant.go`
- For all others, clean code according to upgraded linter