### PR TITLE
Simplify 'Trace' library to prevent it from data race issue

### DIFF
--- a/store/redis/master.go
+++ b/store/redis/master.go
@@ -66,7 +66,8 @@ func NewMasterCache(master *dbdrivers.RedisDBConn, prefix string, opts ...Master
 			clients: map[uint64]*dbdrivers.RedisDBConn{
 				masterID: master,
 			},
-			prefix: prefix,
+			prefix:    prefix,
+			operation: "master-cache", // by default
 		},
 	}
 
@@ -79,16 +80,13 @@ func NewMasterCache(master *dbdrivers.RedisDBConn, prefix string, opts ...Master
 
 type MasterCacheOption func(*masterCache)
 
-// OptTraceMC is an option that enables tracing for all redis operations in MasterCache with the given operation name
-// if you enable Sentry's sampling for traces in cofing.
-// The operation name will be `master-cache` by default if it is passed an empty string.
-func OptTraceMC(operation string) MasterCacheOption {
+// OptTraceMCOperation is an option to set the operation name for tracing in MasterCache.
+// It overrides the default value as long as the given operation name is not empty.
+func OptTraceMCOperation(operation string) MasterCacheOption {
 	return func(m *masterCache) {
 		if t, ok := m.cache.(*tenantCache); ok {
 			if operation != "" {
 				t.operation = operation
-			} else {
-				t.operation = "master-cache" // by default
 			}
 		}
 	}

--- a/store/redis/master.go
+++ b/store/redis/master.go
@@ -54,7 +54,7 @@ type MasterCache interface {
 }
 
 type masterCache struct {
-	cache TenantCache // cache is a tenantCache with only master redis db; map[masterID]*redis.Client
+	cache *tenantCache // cache is a tenantCache with only master redis db; map[masterID]*redis.Client
 }
 
 // NewMasterCache creates a new MasterCache.
@@ -80,14 +80,12 @@ func NewMasterCache(master *dbdrivers.RedisDBConn, prefix string, opts ...Master
 
 type MasterCacheOption func(*masterCache)
 
-// OptTraceMCOperation is an option to set the operation name for tracing in MasterCache.
-// It overrides the default value as long as the given operation name is not empty.
+// OptTraceMCOperation is an option to set an operation name for tracing in MasterCache.
+// It overrides a default value as long as the given operation name is not empty.
 func OptTraceMCOperation(operation string) MasterCacheOption {
 	return func(m *masterCache) {
-		if t, ok := m.cache.(*tenantCache); ok {
-			if operation != "" {
-				t.operation = operation
-			}
+		if operation != "" {
+			m.cache.operation = operation
 		}
 	}
 }

--- a/store/redis/tenant.go
+++ b/store/redis/tenant.go
@@ -85,8 +85,8 @@ func NewTenantCache(tenants map[uint64]*dbdrivers.RedisDBConn, prefix string, op
 
 type TenantCacheOption func(*tenantCache)
 
-// OptTraceOperation is an option to set the operation name for tracing in TenantCache.
-// It overrides the default value as long as the given operation name is not empty.
+// OptTraceOperation is an option to set an operation name for tracing in TenantCache.
+// It overrides a default value as long as the given operation name is not empty.
 func OptTraceTCOperation(operation string) func(*tenantCache) {
 	return func(t *tenantCache) {
 		if operation != "" {

--- a/store/redis/tenant.go
+++ b/store/redis/tenant.go
@@ -71,8 +71,9 @@ type tenantCache struct {
 func NewTenantCache(tenants map[uint64]*dbdrivers.RedisDBConn, prefix string, opts ...TenantCacheOption) TenantCache {
 
 	t := &tenantCache{
-		clients: tenants,
-		prefix:  prefix,
+		clients:   tenants,
+		prefix:    prefix,
+		operation: "tenant-cache", // by default
 	}
 
 	for _, opt := range opts {
@@ -84,15 +85,12 @@ func NewTenantCache(tenants map[uint64]*dbdrivers.RedisDBConn, prefix string, op
 
 type TenantCacheOption func(*tenantCache)
 
-// OptTraceTC is an option that enables tracing for all redis operations in TenantCache with the given operation name
-// if you enable Sentry's sampling for traces in cofing.
-// The operation name will be `tenant-cache` by default if it is passed an empty string.
-func OptTraceTC(operation string) func(*tenantCache) {
+// OptTraceOperation is an option to set the operation name for tracing in TenantCache.
+// It overrides the default value as long as the given operation name is not empty.
+func OptTraceTCOperation(operation string) func(*tenantCache) {
 	return func(t *tenantCache) {
 		if operation != "" {
 			t.operation = operation
-		} else {
-			t.operation = "tenant-cache" // by default
 		}
 	}
 }


### PR DESCRIPTION
- [simplify tracing](https://github.com/retail-ai-inc/bean/commit/c276429148027d1d70c322a1c31b30565cab83e8) 
     - remove `TraceableContext` and related funcs
     - make it immutable by returning a new context to prevent it from data race
       - data race issue occurs between `(*TraceableContext) Pop()` as write and `*TraceableContext.Done()` as read that is triggered by `go-sql-driver/mysql.(*mysqlConn).startWatcher` such as in the case of a bad connection error.
- [provide option to enable tracing with operation name you like](https://github.com/retail-ai-inc/bean/commit/145f615f8610e36b80c84991fac207652a43d037)
  - for redis `MasterCache` and `TenantCache`