### PR TITLE
Unwrap Error in `APIError`

### DIFF
--- a/error/api_error.go
+++ b/error/api_error.go
@@ -70,3 +70,8 @@ func (e *APIError) Error() string {
 	}
 	return "No error detail available"
 }
+
+// Unwrap returns the wrapped error. It is used by errors.Is and errors.As.
+func (e *APIError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
- follow one of conventions in Golang by having a custom error that wraps another error implement [`Unwrap() error `](https://pkg.go.dev/errors#pkg-overview) method
- allow us to utilize [`errors.Is`](https://pkg.go.dev/errors#Is) and [`As`](https://pkg.go.dev/errors#As) to trace a chain of errors.