### PR TITLE
feat: Add Graceful Shutdown to `ServeAt` method

### DIFF
--- a/cmd/bean/internal/project/env.json
+++ b/cmd/bean/internal/project/env.json
@@ -106,7 +106,8 @@
             "certFile": "",
             "privFile": "",
             "minTLSVersion": 1
-        }
+        },
+        "shutdownTimeout": "30s"
     },
     "netHttpFastTransporter": {
         "on": true,


### PR DESCRIPTION
- Make `ServeAt` return an error so that handling the error is left to bean user side.
- Add `ShutdownTimeout` (30s by default) to `bean.Config`