### PR TITLE
feat: check config loaded, improve single flight

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20' # Make sure to specify the current version of Go the project is using
+        go-version: '1.21' # Make sure to specify the current version of Go the project is using
 
     - name: Lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOPATH=$(shell go env GOPATH)
-# v1.55.2 is the latest version of golangci-lint project based on Go 1.20
-# change it according to the Go version this project is using
-GOLANGCI_LINT_VERSION=v1.55.2
+# GOLANGCI_LINT_VERSION is the latest version of golangci-lint
+# adjusted to match the Go version used in this project
+GOLANGCI_LINT_VERSION=v1.59.1
 
 all: lint test build
 

--- a/helpers/singleflight_test.go
+++ b/helpers/singleflight_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var timeoutCtx, _ = context.WithTimeout(context.Background(), time.Second)
+var ctxTimeout1s, _ = context.WithTimeoutCause(context.Background(), time.Second, errors.New("single flight timeout"))
 
 func TestSingleDo(t *testing.T) {
 	type args[T any] struct {
@@ -74,7 +74,7 @@ func TestSingleDo(t *testing.T) {
 		{
 			name: "error timeout",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test4",
 				call: func() (string, error) {
 					time.Sleep(time.Millisecond * 500)
@@ -89,7 +89,7 @@ func TestSingleDo(t *testing.T) {
 		{
 			name: "context deadline exceeded",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test5",
 				call: func() (string, error) {
 					time.Sleep(time.Millisecond * 500)
@@ -104,7 +104,7 @@ func TestSingleDo(t *testing.T) {
 		{
 			name: "type error",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test6",
 				call: func() (string, error) {
 					return "123", nil
@@ -113,7 +113,7 @@ func TestSingleDo(t *testing.T) {
 				ttl:   nil,
 			},
 			previous: &args[int]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test6",
 				call: func() (int, error) {
 					time.Sleep(time.Millisecond * 500)
@@ -224,7 +224,7 @@ func TestSingleDoChan(t *testing.T) {
 		{
 			name: "timeout failed",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test5",
 				call: func() (string, error) {
 					time.Sleep(time.Second * 2)
@@ -239,7 +239,7 @@ func TestSingleDoChan(t *testing.T) {
 		{
 			name: "error timeout",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test6",
 				call: func() (string, error) {
 					time.Sleep(time.Millisecond * 500)
@@ -254,7 +254,7 @@ func TestSingleDoChan(t *testing.T) {
 		{
 			name: "context deadline exceeded",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test7",
 				call: func() (string, error) {
 					time.Sleep(time.Millisecond * 500)
@@ -269,7 +269,7 @@ func TestSingleDoChan(t *testing.T) {
 		{
 			name: "type error",
 			args: args[string]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test8",
 				call: func() (string, error) {
 					return "123", nil
@@ -278,7 +278,7 @@ func TestSingleDoChan(t *testing.T) {
 				ttl:   nil,
 			},
 			previous: &args[int]{
-				ctx: timeoutCtx,
+				ctx: ctxTimeout1s,
 				key: "test8",
 				call: func() (int, error) {
 					time.Sleep(time.Millisecond * 500)
@@ -309,6 +309,8 @@ func TestSingleDoChan(t *testing.T) {
 			if !reflect.DeepEqual(gotData, tt.wantData) {
 				t.Errorf("SingleDoChan() gotData = %v, want %v", gotData, tt.wantData)
 			}
+			fmt.Printf("[%s] gotData: %+v\n", tt.name, gotData)
+			fmt.Printf("[%s] error: %+v\n", tt.name, err)
 			if tt.args.retry > 0 && err != nil {
 				// waiting for goroutine finish
 				time.Sleep(2 * time.Second)

--- a/test/setup.go
+++ b/test/setup.go
@@ -3,6 +3,7 @@ package test
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/retail-ai-inc/bean/v2"
 	"github.com/spf13/viper"
@@ -40,14 +41,27 @@ type CfgOption func(*TestConfig)
 
 // SetupConfig initializes the configuration and accepts optional configuration functions.
 // please ensure that config file contains `test` section.
-func SetupConfig(configPath string, opts ...CfgOption) error {
+func SetupConfig(filename string, opts ...CfgOption) error {
 	for _, opt := range opts {
 		opt(&TestCfg)
 	}
 
-	viper.AddConfigPath(configPath)
-	viper.SetConfigType("json")
-	viper.SetConfigName("env")
+	ext := filepath.Ext(filename)
+	if ext == "" {
+		return fmt.Errorf("file extension is missing in the filename")
+	}
+
+	absPath, err := filepath.Abs(filename)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+	path := filepath.Dir(absPath)
+	name := filepath.Base(filename[:len(filename)-len(ext)])
+
+	viper.AddConfigPath(path)
+	viper.SetConfigType(ext[1:])
+	viper.SetConfigName(name)
+
 	if err := viper.ReadInConfig(); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Config
  - Change `BeanConfig` singleton to the pointer in order to check if it was loaded
  - Provide a new func to load the config with a given filename
- Single flight
  - replace `time.After` with `time.Timer` for more efficient memory usage
    - FYI, you can see [Golang <-time.After() is not garbage collected before expiry](https://medium.com/@oboturov/golang-time-after-is-not-garbage-collected-4cbc94740082)
  - support context's cause (https://pkg.go.dev/context@go1.21.0#WithTimeoutCause)
- Others
  - Improve test util func
  - Upgrade linter version adjusted to match go1.21
  