### PR TITLE
feat: 🎸 enhance async task execution with `context.Context`

### DIFF
--- a/async/async.go
+++ b/async/async.go
@@ -209,7 +209,7 @@ type asyncOptions struct {
 
 // ExecuteWithContext execute a function returning an error asynchronously
 // with a starndard context (not echo context), recovering if they panic.
-func ExecuteContext(fn TimeoutTask, ctx context.Context, asyncOpts ...AsyncOption) {
+func ExecuteContext(ctx context.Context, fn TimeoutTask, asyncOpts ...AsyncOption) {
 
 	// by default
 	opts := &asyncOptions{

--- a/async/async.go
+++ b/async/async.go
@@ -233,12 +233,13 @@ func ExecuteContext(fn TimeoutTask, ctx context.Context, asyncOpts ...AsyncOptio
 		// Set scope to the hub.
 		hub := sentry.GetHubFromContext(ctx)
 		if hub == nil {
-			hub = sentry.CurrentHub().Clone()
+			hub = sentry.CurrentHub()
 		}
+		clone := hub.Clone()
 		if reqFound {
-			hub.Scope().SetRequest(req)
+			clone.Scope().SetRequest(req)
 		}
-		newCtx = sentry.SetHubOnContext(newCtx, hub)
+		newCtx = sentry.SetHubOnContext(newCtx, clone)
 
 		// Set the sentry options.
 		if config.Bean.Sentry.TracesSampleRate > 0.0 {
@@ -348,14 +349,15 @@ func recoverPanic(c context.Context) {
 			}
 
 			if localHub == nil {
-				localHub = sentry.CurrentHub().Clone()
+				localHub = sentry.CurrentHub()
 			}
+			clone := localHub.Clone()
 
-			localHub.ConfigureScope(func(scope *sentry.Scope) {
+			clone.ConfigureScope(func(scope *sentry.Scope) {
 				scope.SetTag("goroutine", "true")
 			})
 
-			localHub.Recover(v)
+			clone.Recover(v)
 		}
 
 		msg := map[string]interface{}{

--- a/bean.go
+++ b/bean.go
@@ -325,6 +325,7 @@ func NewEcho() (*echo.Echo, func() error) {
 				Repanic: true,
 				Timeout: config.Bean.Sentry.Timeout,
 			}))
+			e.Use(middleware.SetHubToContext)
 
 			if helpers.FloatInRange(config.Bean.Sentry.TracesSampleRate, 0.0, 1.0) > 0.0 {
 				regex.SetSamplingPathSkipper(config.Bean.Sentry.SkipTracesEndpoints)
@@ -344,7 +345,9 @@ func NewEcho() (*echo.Echo, func() error) {
 	// IMPORTANT: Request related middleware.
 	// Set the `X-Request-ID` header field if it doesn't exist.
 	e.Use(echomiddleware.RequestIDWithConfig(echomiddleware.RequestIDConfig{
-		Generator: uuid.NewString,
+		Generator:        uuid.NewString,
+		RequestIDHandler: middleware.RequestIDHandler,
+		TargetHeader:     echo.HeaderXRequestID,
 	}))
 
 	// Enable prometheus metrics middleware. Metrics data should be accessed via `/metrics` endpoint.

--- a/context/key_value.go
+++ b/context/key_value.go
@@ -1,0 +1,62 @@
+package context
+
+import (
+	"context"
+	"net/http"
+)
+
+type key struct{ string }
+
+var (
+	requestID   = key{"request_id"}
+	httpRequest = key{"http_request"}
+	// TODO: Add more keys here as needed.
+)
+
+func GetRequestID(ctx context.Context) (string, bool) {
+	return getNotEmptyStr(ctx, requestID)
+}
+
+func SetRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestID, id)
+}
+
+func GetRequest(ctx context.Context) (*http.Request, bool) {
+	return getNonNilPtr(ctx, httpRequest)
+}
+
+func SetRequest(ctx context.Context, req *http.Request) context.Context {
+	return context.WithValue(ctx, httpRequest, req)
+}
+
+type ptr interface {
+	*http.Request
+	// TODO: Add more type constraints here as needed.
+}
+
+func getNotEmptyStr(ctx context.Context, k key) (string, bool) {
+	str, ok := ctx.Value(k).(string)
+	if !ok {
+		return "", false
+	}
+
+	if str == "" {
+		return "", false
+	}
+
+	return str, true
+}
+
+func getNonNilPtr[T ptr](ctx context.Context, k key) (T, bool) {
+	v, ok := ctx.Value(k).(T)
+	if !ok {
+		return nil, false
+	}
+
+	// return false even when nil pointer is stored.
+	if v == nil {
+		return nil, false
+	}
+
+	return v, true
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/retail-ai-inc/bean/v2
 
-go 1.22.7
-toolchain go1.23.4
+go 1.23.4
 
 require (
 	github.com/alphadose/haxmap v1.4.1

--- a/internal/middleware/capture.go
+++ b/internal/middleware/capture.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	bctx "github.com/retail-ai-inc/bean/v2/context"
+
+	"github.com/getsentry/sentry-go"
+	sentryecho "github.com/getsentry/sentry-go/echo"
+	"github.com/labstack/echo/v4"
+)
+
+// SetHubToContext sets the sentry hub to the context.
+var SetHubToContext = func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+
+		ctx := c.Request().Context()
+
+		if sentry.GetHubFromContext(ctx) == nil {
+			if hub := sentryecho.GetHubFromContext(c); hub != nil {
+				// Set sentry hub to the context as well as the echo context if not found.
+				// so that you can take it out from the context, too.
+				ctx = sentry.SetHubOnContext(ctx, hub)
+			}
+		}
+
+		if _, ok := bctx.GetRequest(ctx); !ok {
+			// Set request to the context as well as the echo context if not found.
+			// The request may be used later for tracing an aync task spawned by the request.
+			ctx = bctx.SetRequest(ctx, c.Request())
+		}
+
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		return next(c)
+	}
+}

--- a/internal/middleware/request_id.go
+++ b/internal/middleware/request_id.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+	bctx "github.com/retail-ai-inc/bean/v2/context"
+)
+
+var RequestIDHandler = func(c echo.Context, requestID string) {
+
+	// Set the request ID in the echo context if not set.
+	if v, ok := c.Get(echo.HeaderXRequestID).(string); !ok || v == "" {
+		c.Set(echo.HeaderXRequestID, requestID)
+	}
+
+	ctx := c.Request().Context()
+
+	if _, ok := bctx.GetRequestID(ctx); !ok {
+		// Set the request ID in the context as well if not found.
+		ctx = bctx.SetRequestID(ctx, requestID)
+	}
+
+	c.SetRequest(c.Request().WithContext(ctx))
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,11 +1,29 @@
 package log
 
-import "github.com/labstack/echo/v4"
+import (
+	"sync"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
+)
 
 // This is a global variable to hold the debug logger so that we can log data from service, repository or anywhere.
 var logger echo.Logger
+var mu sync.Mutex
+
+func New() echo.Logger {
+	if logger == nil {
+		mu.Lock()
+		logger = log.New("echo")
+		mu.Unlock()
+	}
+
+	return logger
+}
 
 func Set(l echo.Logger) {
+	mu.Lock()
+	defer mu.Unlock()
 	logger = l
 }
 

--- a/sync/pool.go
+++ b/sync/pool.go
@@ -136,11 +136,12 @@ func setSpan(ctx context.Context, req *http.Request) *sentry.Span {
 	if config.Bean.Sentry.On {
 		hub := sentry.GetHubFromContext(ctx)
 		if hub == nil {
-			hub = sentry.CurrentHub().Clone()
+			hub = sentry.CurrentHub()
 		}
+		clone := hub.Clone()
 
-		hub.Scope().SetRequest(req)
-		ctx = sentry.SetHubOnContext(ctx, hub)
+		clone.Scope().SetRequest(req)
+		ctx = sentry.SetHubOnContext(ctx, clone)
 
 		if config.Bean.Sentry.TracesSampleRate > 0.0 {
 			urlPath := req.URL.Path
@@ -173,11 +174,12 @@ func capturePanic(ctx context.Context, err error) {
 			localHub = sentry.GetHubFromContext(ctx)
 		}
 		if localHub == nil {
-			localHub = sentry.CurrentHub().Clone()
+			localHub = sentry.CurrentHub()
 		}
-		localHub.ConfigureScope(func(scope *sentry.Scope) {
+		clone := localHub.Clone()
+		clone.ConfigureScope(func(scope *sentry.Scope) {
 			scope.SetTag("goroutine", "true")
 		})
-		localHub.Recover(err)
+		clone.Recover(err)
 	}
 }

--- a/trace/capture.go
+++ b/trace/capture.go
@@ -13,6 +13,8 @@ import (
 
 // SentryCaptureExceptionWithEcho captures an exception with echo context and send to sentry if sentry is configured.
 // It caputures the exception even if the context or sentry hub in the context is nil.
+// To capture an exception with a stack trace, include the top-level error.
+// For supported libraries, see: https://pkg.go.dev/github.com/getsentry/sentry-go@v0.30.0#ExtractStacktrace
 func SentryCaptureExceptionWithEcho(c echo.Context, err error) {
 
 	sentryCaptureException(err, false, func() (*sentry.Hub, bool) {
@@ -27,6 +29,8 @@ func SentryCaptureExceptionWithEcho(c echo.Context, err error) {
 
 // SentryCaptureException captures an exception with context and send to sentry if sentry is configured.
 // It caputures the exception even if the context or sentry hub in the context is nil.
+// To capture an exception with a stack trace, include the top-level error.
+// For supported libraries, see: https://pkg.go.dev/github.com/getsentry/sentry-go@v0.30.0#ExtractStacktrace
 func SentryCaptureException(ctx context.Context, err error) {
 
 	sentryCaptureException(err, false, func() (*sentry.Hub, bool) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -41,12 +41,15 @@ import (
 // It also carries over the sentry hub from the echo context to child context.
 // Make sure to call the returned function to finish the span.
 func StartSpanWithEcho(c echo.Context, operation string, spanOpts ...sentry.SpanOption) (context.Context, func()) {
-	var ctx context.Context
-	if hub := sentryecho.GetHubFromContext(c); hub != nil {
-		ctx = sentry.SetHubOnContext(c.Request().Context(), hub)
-	} else {
-		ctx = c.Request().Context()
+
+	ctx := c.Request().Context()
+
+	if sentry.GetHubFromContext(ctx) == nil {
+		if hub := sentryecho.GetHubFromContext(c); hub != nil {
+			ctx = sentry.SetHubOnContext(ctx, hub)
+		}
 	}
+
 	return startSpan(ctx, operation, 1, spanOpts...)
 }
 


### PR DESCRIPTION
- Enhance async task execution with `context.Context`
  - Trace and sample the async task **seamlessly, continuing from parent span**
     - (by `sentry.ContinueFromHeaders`) 
  - Capture an error **with the parent `sentry.Hub` and scoped `http.Request`** if it is encountered. 
     - (the local hub and request info are in advance carried over from `echo.Context` to `context.Context` through new `SetHubToContext` middleware)
  - Log an error **with the request id** if it is encountered. 
       - (the request id is set through new `RequestIDHandler` func)