### PR TITLE
feat: 🎸 execute async task with default pool

### DIFF
--- a/async/async.go
+++ b/async/async.go
@@ -209,7 +209,7 @@ type asyncOptions struct {
 
 // ExecuteWithContext execute a function returning an error asynchronously
 // with a starndard context (not echo context), recovering if they panic.
-func ExecuteContext(fn TimeoutTask, ctx context.Context, asyncOpts ...AsyncOption) {
+func ExecuteContext(ctx context.Context, fn TimeoutTask, asyncOpts ...AsyncOption) {
 
 	// by default
 	opts := &asyncOptions{

--- a/async/async.go
+++ b/async/async.go
@@ -233,12 +233,13 @@ func ExecuteContext(fn TimeoutTask, ctx context.Context, asyncOpts ...AsyncOptio
 		// Set scope to the hub.
 		hub := sentry.GetHubFromContext(ctx)
 		if hub == nil {
-			hub = sentry.CurrentHub().Clone()
+			hub = sentry.CurrentHub()
 		}
+		clone := hub.Clone()
 		if reqFound {
-			hub.Scope().SetRequest(req)
+			clone.Scope().SetRequest(req)
 		}
-		newCtx = sentry.SetHubOnContext(newCtx, hub)
+		newCtx = sentry.SetHubOnContext(newCtx, clone)
 
 		// Set the sentry options.
 		if config.Bean.Sentry.TracesSampleRate > 0.0 {
@@ -348,14 +349,15 @@ func recoverPanic(c context.Context) {
 			}
 
 			if localHub == nil {
-				localHub = sentry.CurrentHub().Clone()
+				localHub = sentry.CurrentHub()
 			}
+			clone := localHub.Clone()
 
-			localHub.ConfigureScope(func(scope *sentry.Scope) {
+			clone.ConfigureScope(func(scope *sentry.Scope) {
 				scope.SetTag("goroutine", "true")
 			})
 
-			localHub.Recover(v)
+			clone.Recover(v)
 		}
 
 		msg := map[string]interface{}{

--- a/async/async.go
+++ b/async/async.go
@@ -366,7 +366,7 @@ func newTask(ctx context.Context, fn TaskWithCtx,
 		// Run the task with the context.
 		err := fn(ctx)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) && context.Cause(ctx) == ErrTaskTimeout {
+			if !errors.Is(err, ErrTaskTimeout) && context.Cause(ctx) == ErrTaskTimeout {
 				err = errors.Join(ErrTaskTimeout, err)
 			}
 			trace.SentryCaptureException(ctx, err)

--- a/async/async.go
+++ b/async/async.go
@@ -288,7 +288,7 @@ func newContext(current context.Context, sentryOn bool, timeout time.Duration) (
 
 func setupSentrySampling(current context.Context) []sentry.SpanOption {
 
-	opts := make([]sentry.SpanOption, 0, 3) // continue from headers, description, transaction name at least
+	opts := make([]sentry.SpanOption, 0, 4)
 
 	// Continue the trace by passing the sentry-trace id, not by sharing the same span object, like distributed tracing across different servers.
 	// This is because the same span in the context is used in multiple goroutines, which causes a data race issue.

--- a/async/async.go
+++ b/async/async.go
@@ -193,12 +193,16 @@ func CaptureException(c context.Context, err error) {
 
 type AsyncOption func(*asyncOptions)
 
+// WithPoolName sets the pool name for the async task.
+// If the pool name is not provided, the default pool will be used.
 func WithPoolName(poolName string) AsyncOption {
 	return func(o *asyncOptions) {
 		o.poolName = poolName
 	}
 }
 
+// WithTimeout sets the timeout for the async task.
+// If the timeout is not provided, the task will run without a timeout.
 func WithTimeout(d time.Duration) AsyncOption {
 	return func(o *asyncOptions) {
 		o.timeout = d

--- a/async/aysnc_test.go
+++ b/async/aysnc_test.go
@@ -1,0 +1,131 @@
+package async
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/retail-ai-inc/bean/v2/config"
+	bctx "github.com/retail-ai-inc/bean/v2/context"
+	"github.com/retail-ai-inc/bean/v2/internal/gopool"
+	"github.com/retail-ai-inc/bean/v2/log"
+	"github.com/retail-ai-inc/bean/v2/trace"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Execute_Context(t *testing.T) {
+	config.Bean = &config.Config{Sentry: config.Sentry{
+		On:               false,
+		TracesSampleRate: 0,
+	},
+	}
+	_ = log.New()
+
+	task := func(ctx context.Context) error {
+		_, finish := trace.StartSpan(ctx, "test")
+		defer finish()
+		return nil
+	}
+
+	newCtx := func() context.Context {
+		return bctx.SetRequestID(context.Background(), uuid.NewString())
+	}
+
+	type testCase struct {
+		name      string
+		ctx       context.Context
+		regPool   func() error
+		task      TaskWithCtx
+		asyncOpts []AsyncOption
+		wantError bool
+	}
+
+	tests := []testCase{
+		{
+			name:      "Successful_task_execution_without_options",
+			ctx:       newCtx(),
+			task:      task,
+			asyncOpts: nil,
+			wantError: false,
+		},
+		{
+			name: "Task_execution_with_timeout",
+			ctx:  newCtx(),
+			task: func(ctx context.Context) error {
+				_, finish := trace.StartSpan(ctx, "test")
+				defer finish()
+
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(100 * time.Millisecond):
+					return nil
+				}
+			},
+			asyncOpts: []AsyncOption{WithTimeout(50 * time.Millisecond)},
+			wantError: false,
+		},
+		{
+			name: "Task_execution_with_a_pool_name",
+			ctx:  newCtx(),
+			regPool: func() error {
+				pool, err := gopool.NewPool(nil, nil)
+				if err != nil {
+					return err
+				}
+				return gopool.Register("testPool", pool)
+			},
+			task:      task,
+			asyncOpts: []AsyncOption{WithPoolName("testPool")},
+			wantError: false,
+		},
+		{
+			name: "Task_returning_an_error",
+			ctx:  newCtx(),
+			task: func(ctx context.Context) error {
+				_, finish := trace.StartSpan(ctx, "test")
+				defer finish()
+
+				return fmt.Errorf("test task error")
+			},
+			asyncOpts: nil,
+			wantError: false,
+		},
+		{
+			name: "Panic_in_task_execution",
+			ctx:  newCtx(),
+			task: func(ctx context.Context) error {
+				_, finish := trace.StartSpan(ctx, "test")
+				defer finish()
+
+				panic("simulated panic")
+			},
+			asyncOpts: nil,
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.regPool != nil {
+				err := tt.regPool()
+				require.NoError(t, err)
+			}
+
+			// Act
+			err := ExecuteContext(tt.ctx, tt.task, tt.asyncOpts...)
+
+			// Assert
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/bean.go
+++ b/bean.go
@@ -325,6 +325,7 @@ func NewEcho() (*echo.Echo, func() error) {
 				Repanic: true,
 				Timeout: config.Bean.Sentry.Timeout,
 			}))
+			e.Use(middleware.SetHubToContext)
 
 			if helpers.FloatInRange(config.Bean.Sentry.TracesSampleRate, 0.0, 1.0) > 0.0 {
 				regex.SetSamplingPathSkipper(config.Bean.Sentry.SkipTracesEndpoints)
@@ -344,7 +345,9 @@ func NewEcho() (*echo.Echo, func() error) {
 	// IMPORTANT: Request related middleware.
 	// Set the `X-Request-ID` header field if it doesn't exist.
 	e.Use(echomiddleware.RequestIDWithConfig(echomiddleware.RequestIDConfig{
-		Generator: uuid.NewString,
+		Generator:        uuid.NewString,
+		RequestIDHandler: middleware.RequestIDHandler,
+		TargetHeader:     echo.HeaderXRequestID,
 	}))
 
 	// Enable prometheus metrics middleware. Metrics data should be accessed via `/metrics` endpoint.

--- a/bean.go
+++ b/bean.go
@@ -384,8 +384,8 @@ func NewEcho() (*echo.Echo, func() error) {
 				e.Logger.Fatal(err, ". Server 🚀  crash landed. Exiting...")
 			}
 		}
-		closes = append(closes, gopool.UnregisterAllPools)
 	}
+	closes = append(closes, gopool.ReleaseAllPools(config.Bean.AsyncPoolReleaseTimeout))
 
 	return e, closer(closes)
 }

--- a/cmd/bean/internal/project/env.json
+++ b/cmd/bean/internal/project/env.json
@@ -222,5 +222,6 @@
             "size": 10,
             "blockAfter": 10000
         }
-    ]
+    ],
+    "asyncPoolReleaseTimeout": "25s"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -131,6 +131,7 @@ type Config struct {
 		Size       *int
 		BlockAfter *int
 	}
+	AsyncPoolReleaseTimeout time.Duration
 }
 
 type Sentry struct {

--- a/context/key_value.go
+++ b/context/key_value.go
@@ -1,0 +1,62 @@
+package context
+
+import (
+	"context"
+	"net/http"
+)
+
+type key struct{ string }
+
+var (
+	requestID   = key{"request_id"}
+	httpRequest = key{"http_request"}
+	// TODO: Add more keys here as needed.
+)
+
+func GetRequestID(ctx context.Context) (string, bool) {
+	return getNotEmptyStr(ctx, requestID)
+}
+
+func SetRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, requestID, id)
+}
+
+func GetRequest(ctx context.Context) (*http.Request, bool) {
+	return getNonNilPtr(ctx, httpRequest)
+}
+
+func SetRequest(ctx context.Context, req *http.Request) context.Context {
+	return context.WithValue(ctx, httpRequest, req)
+}
+
+type ptr interface {
+	*http.Request
+	// TODO: Add more type constraints here as needed.
+}
+
+func getNotEmptyStr(ctx context.Context, k key) (string, bool) {
+	str, ok := ctx.Value(k).(string)
+	if !ok {
+		return "", false
+	}
+
+	if str == "" {
+		return "", false
+	}
+
+	return str, true
+}
+
+func getNonNilPtr[T ptr](ctx context.Context, k key) (T, bool) {
+	v, ok := ctx.Value(k).(T)
+	if !ok {
+		return nil, false
+	}
+
+	// return false even when nil pointer is stored.
+	if v == nil {
+		return nil, false
+	}
+
+	return v, true
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12
 	github.com/labstack/echo-contrib v0.17.2

--- a/internal/gopool/pool.go
+++ b/internal/gopool/pool.go
@@ -87,6 +87,7 @@ func Register(name string, pool *ants.Pool) error {
 }
 
 // UnregisterAllPools removes all pools in non-blocking way.
+// It releases the default pool as well.
 func UnregisterAllPools() {
 	poolsMu.Lock()
 	defer poolsMu.Unlock()
@@ -104,42 +105,58 @@ func UnregisterAllPools() {
 	}
 }
 
-// UnregisterAllPoolsTimeout removes all pools in blocking way with a timeout.
-func UnregisterAllPoolsTimeout(timeout time.Duration) error {
+var ErrReleaseTimeout = errors.New("gopool: release timeout")
 
-	if timeout <= 0 {
-		UnregisterAllPools()
+// ReleaseAllPools provides a func to removes all pools in blocking way with a timeout.
+// It releases the default pool as well.
+func ReleaseAllPools(timeout time.Duration) func() error {
+	return func() error {
+		if timeout <= 0 {
+			UnregisterAllPools()
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeoutCause(context.Background(), timeout, ErrReleaseTimeout)
+		defer cancel()
+
+		poolsMu.Lock()
+		defer poolsMu.Unlock()
+		// Basically ReleaseTimeout() is in blocking way,
+		// which means it will wait for the tasks to be finished within the timeout.
+		p := pool.New().WithContext(ctx).WithMaxGoroutines(len(pools) + 1)
+		for name, pool := range pools {
+			p.Go(releaser(name, pool, timeout))
+		}
+		if defaultPool != nil {
+			p.Go(releaser("default", defaultPool, timeout))
+		}
+
+		err := p.Wait()
+		if err != nil {
+			return err
+		}
+		pools = make(map[string]*ants.Pool) // reset pools
+		// Do not reset the default pool
+
 		return nil
 	}
-
-	var ErrReleaseTimeout = errors.New("gopool: release timeout")
-	ctx, cancel := context.WithTimeoutCause(context.Background(), timeout, ErrReleaseTimeout)
-	defer cancel()
-
-	poolsMu.Lock()
-	defer poolsMu.Unlock()
-	// Basically ReleaseTimeout() is in blocking way,
-	// which means it will wait for the tasks to be finished within the timeout.
-	p := pool.New().WithContext(ctx).WithMaxGoroutines(len(pools) + 1)
-	for name, pool := range pools {
-		p.Go(releaser(name, pool, timeout))
-	}
-	if defaultPool != nil {
-		p.Go(releaser("default", defaultPool, timeout))
-	}
-
-	err := p.Wait()
-	if err != nil {
-		return err
-	}
-	pools = make(map[string]*ants.Pool) // reset pools
-	// Do not reset the default pool
-
-	return nil
 }
 
 func releaser(name string, pool *ants.Pool, timeout time.Duration) func(context.Context) error {
 	return func(ctx context.Context) (err error) {
+
+		// For a short timeout value, check if the context is done before releasing.
+		select {
+		case <-ctx.Done():
+			err := context.Cause(ctx)
+			if errors.Is(err, ErrReleaseTimeout) {
+				return fmt.Errorf("pool[%s] release cancelled due to timeout", name)
+			} else {
+				return fmt.Errorf("pool[%s] release cancelled: %w", name, err)
+			}
+		default:
+		}
+
 		var catcher panics.Catcher
 		defer func() {
 			if r := catcher.Recovered(); r != nil {

--- a/internal/gopool/pool.go
+++ b/internal/gopool/pool.go
@@ -129,8 +129,6 @@ func GetPool(poolName string) (*ants.Pool, error) {
 
 // GetDefaultPool returns the default pool.
 func GetDefaultPool() *ants.Pool {
-	poolsMu.Lock()
-	defer poolsMu.Unlock()
 	return defaultPool
 }
 

--- a/internal/gopool/pool_test.go
+++ b/internal/gopool/pool_test.go
@@ -1,0 +1,221 @@
+package gopool
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/panjf2000/ants/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Register_Pool(t *testing.T) {
+	type args struct {
+		name string
+		pool *ants.Pool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		call    int
+		wantErr bool
+	}{
+		{
+			name: "register",
+			args: args{
+				name: "test",
+				pool: newPool(t),
+			},
+			call:    1,
+			wantErr: false,
+		},
+		{
+			name: "register_nil_pool",
+			args: args{
+				name: "test",
+				pool: nil,
+			},
+			call:    1,
+			wantErr: true,
+		},
+		{
+			name: "register_twice",
+			args: args{
+				name: "test",
+				pool: newPool(t),
+			},
+			call:    2,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup(t)
+
+			var err error
+			for i := 0; i < tt.call; i++ {
+				err = Register(tt.args.name, tt.args.pool)
+			}
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_Get_Pool(t *testing.T) {
+	type args struct {
+		name string
+		pool *ants.Pool
+	}
+	tests := []struct {
+		name     string
+		args     args
+		poolName string
+		wantErr  bool
+	}{
+		{
+			name: "get",
+			args: args{
+				name: "test",
+				pool: newPool(t),
+			},
+			poolName: "test",
+			wantErr:  false,
+		},
+		{
+			name: "get_not_found",
+			args: args{
+				name: "test",
+				pool: newPool(t),
+			},
+			poolName: "wrong_name",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup(t)
+
+			err := Register(tt.args.name, tt.args.pool)
+			require.NoError(t, err)
+
+			got, err := GetPool(tt.poolName)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func Test_Unregister_All_Pools(t *testing.T) {
+
+	submitTask := func(dur time.Duration) func(*testing.T) error {
+		task := func(name string, dur time.Duration) func() {
+			return func() {
+				log.Printf("[%7s]task start (%s)", name, dur)
+				defer log.Printf("[%7s]task end   (%s)", name, dur)
+				time.Sleep(dur)
+			}
+		}
+
+		return func(t *testing.T) error {
+			pool := newPool(t)
+			err := Register("test", pool)
+			if err != nil {
+				return err
+			}
+
+			err = pool.Submit(task("test", dur))
+			if err != nil {
+				return err
+			}
+
+			defPool := GetDefaultPool()
+			err = defPool.Submit(task("default", dur*2))
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+
+	type args struct {
+		timeout time.Duration
+	}
+	tests := []struct {
+		name       string
+		args       args
+		submitTask func(*testing.T) error
+		wantErr    bool
+	}{
+		{
+			name: "unregister_withou_timeout",
+			args: args{
+				timeout: 0,
+			},
+			submitTask: nil,
+			wantErr:    false,
+		},
+		{
+			name: "unregister_with_timeout_success",
+			args: args{
+				timeout: 3 * time.Second,
+			},
+			submitTask: submitTask(1 * time.Second),
+			wantErr:    false,
+		},
+		{
+			name: "unregister_with_timeout_fail",
+			args: args{
+				timeout: 2 * time.Second,
+			},
+			submitTask: submitTask(1 * time.Second),
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup(t)
+
+			if tt.submitTask != nil {
+				err := tt.submitTask(t)
+				require.NoError(t, err)
+			}
+
+			err := UnregisterAllPoolsTimeout(tt.args.timeout)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_Get_Default_Pool(t *testing.T) {
+	pool := GetDefaultPool()
+	assert.NotNil(t, pool)
+}
+
+func newPool(t *testing.T) *ants.Pool {
+	t.Helper()
+
+	pool, err := ants.NewPool(0)
+	require.NoError(t, err)
+	return pool
+}
+
+func setup(t *testing.T) {
+	t.Helper()
+
+	defaultPool = initDefaultPool()
+	pools = make(map[string]*ants.Pool)
+}

--- a/internal/gopool/pool_test.go
+++ b/internal/gopool/pool_test.go
@@ -7,10 +7,59 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/panjf2000/ants/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_New_Pool(t *testing.T) {
+	type args struct {
+		size       *int
+		blockAfter *int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ants.Pool
+		wantErr bool
+	}{
+		{
+			name: "new_pool_success",
+			args: args{
+				size:       nil,
+				blockAfter: nil,
+			},
+			want:    func() *ants.Pool { p, _ := ants.NewPool(0); return p }(),
+			wantErr: false,
+		},
+		{
+			name: "new_pool_with_size_and_block_after",
+			args: args{
+				size:       func() *int { i := 1; return &i }(),
+				blockAfter: func() *int { i := 1; return &i }(),
+			},
+			want:    func() *ants.Pool { p, _ := ants.NewPool(1, ants.WithMaxBlockingTasks(1)); return p }(),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewPool(tt.args.size, tt.args.blockAfter)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+			}
+
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(ants.Pool{})); diff != "" {
+				t.Errorf("NewPool() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func Test_Register_Pool(t *testing.T) {
 	type args struct {

--- a/internal/gopool/pool_test.go
+++ b/internal/gopool/pool_test.go
@@ -212,7 +212,7 @@ func Test_Unregister_All_Pools(t *testing.T) {
 			}
 
 			// Act
-			err := UnregisterAllPoolsTimeout(tt.args.timeout)
+			err := ReleaseAllPools(tt.args.timeout)()
 
 			// Assert
 			if tt.wantErr {

--- a/internal/middleware/capture.go
+++ b/internal/middleware/capture.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	bctx "github.com/retail-ai-inc/bean/v2/context"
+
+	"github.com/getsentry/sentry-go"
+	sentryecho "github.com/getsentry/sentry-go/echo"
+	"github.com/labstack/echo/v4"
+)
+
+// SetHubToContext sets the sentry hub to the context.
+var SetHubToContext = func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+
+		ctx := c.Request().Context()
+
+		if sentry.GetHubFromContext(ctx) == nil {
+			if hub := sentryecho.GetHubFromContext(c); hub != nil {
+				// Set sentry hub to the context as well as the echo context if not found.
+				// so that you can take it out from the context, too.
+				ctx = sentry.SetHubOnContext(ctx, hub)
+			}
+		}
+
+		if _, ok := bctx.GetRequest(ctx); !ok {
+			// Set request to the context as well as the echo context if not found.
+			// The request may be used later for tracing an aync task spawned by the request.
+			ctx = bctx.SetRequest(ctx, c.Request())
+		}
+
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		return next(c)
+	}
+}

--- a/internal/middleware/request_id.go
+++ b/internal/middleware/request_id.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+	bctx "github.com/retail-ai-inc/bean/v2/context"
+)
+
+var RequestIDHandler = func(c echo.Context, requestID string) {
+
+	// Set the request ID in the echo context if not set.
+	if v, ok := c.Get(echo.HeaderXRequestID).(string); !ok || v == "" {
+		c.Set(echo.HeaderXRequestID, requestID)
+	}
+
+	ctx := c.Request().Context()
+
+	if _, ok := bctx.GetRequestID(ctx); !ok {
+		// Set the request ID in the context as well if not found.
+		ctx = bctx.SetRequestID(ctx, requestID)
+	}
+
+	c.SetRequest(c.Request().WithContext(ctx))
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,11 +1,29 @@
 package log
 
-import "github.com/labstack/echo/v4"
+import (
+	"sync"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
+)
 
 // This is a global variable to hold the debug logger so that we can log data from service, repository or anywhere.
 var logger echo.Logger
+var mu sync.Mutex
+
+func New() echo.Logger {
+	if logger == nil {
+		mu.Lock()
+		logger = log.New("echo")
+		mu.Unlock()
+	}
+
+	return logger
+}
 
 func Set(l echo.Logger) {
+	mu.Lock()
+	defer mu.Unlock()
 	logger = l
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -8,26 +8,24 @@ import (
 )
 
 // This is a global variable to hold the debug logger so that we can log data from service, repository or anywhere.
-var logger echo.Logger
-var mu sync.Mutex
+var (
+	logger echo.Logger
+	once   sync.Once
+)
 
 func New() echo.Logger {
-	if logger == nil {
-		mu.Lock()
+	once.Do(func() {
 		logger = log.New("echo")
-		mu.Unlock()
-	}
-
+	})
 	return logger
 }
 
+// Set sets the logger. It is not thread-safe.
 func Set(l echo.Logger) {
-	mu.Lock()
-	defer mu.Unlock()
 	logger = l
 }
 
-// The bean Logger to have debug log from anywhere.
+// Logger returns the logger.
 func Logger() echo.Logger {
 	return logger
 }

--- a/sync/pool.go
+++ b/sync/pool.go
@@ -136,11 +136,12 @@ func setSpan(ctx context.Context, req *http.Request) *sentry.Span {
 	if config.Bean.Sentry.On {
 		hub := sentry.GetHubFromContext(ctx)
 		if hub == nil {
-			hub = sentry.CurrentHub().Clone()
+			hub = sentry.CurrentHub()
 		}
+		clone := hub.Clone()
 
-		hub.Scope().SetRequest(req)
-		ctx = sentry.SetHubOnContext(ctx, hub)
+		clone.Scope().SetRequest(req)
+		ctx = sentry.SetHubOnContext(ctx, clone)
 
 		if config.Bean.Sentry.TracesSampleRate > 0.0 {
 			urlPath := req.URL.Path
@@ -173,11 +174,12 @@ func capturePanic(ctx context.Context, err error) {
 			localHub = sentry.GetHubFromContext(ctx)
 		}
 		if localHub == nil {
-			localHub = sentry.CurrentHub().Clone()
+			localHub = sentry.CurrentHub()
 		}
-		localHub.ConfigureScope(func(scope *sentry.Scope) {
+		clone := localHub.Clone()
+		clone.ConfigureScope(func(scope *sentry.Scope) {
 			scope.SetTag("goroutine", "true")
 		})
-		localHub.Recover(err)
+		clone.Recover(err)
 	}
 }

--- a/trace/capture.go
+++ b/trace/capture.go
@@ -13,6 +13,8 @@ import (
 
 // SentryCaptureExceptionWithEcho captures an exception with echo context and send to sentry if sentry is configured.
 // It caputures the exception even if the context or sentry hub in the context is nil.
+// To capture an exception with a stack trace, include the top-level error.
+// For supported libraries, see: https://pkg.go.dev/github.com/getsentry/sentry-go@v0.30.0#ExtractStacktrace
 func SentryCaptureExceptionWithEcho(c echo.Context, err error) {
 
 	sentryCaptureException(err, false, func() (*sentry.Hub, bool) {
@@ -27,6 +29,8 @@ func SentryCaptureExceptionWithEcho(c echo.Context, err error) {
 
 // SentryCaptureException captures an exception with context and send to sentry if sentry is configured.
 // It caputures the exception even if the context or sentry hub in the context is nil.
+// To capture an exception with a stack trace, include the top-level error.
+// For supported libraries, see: https://pkg.go.dev/github.com/getsentry/sentry-go@v0.30.0#ExtractStacktrace
 func SentryCaptureException(ctx context.Context, err error) {
 
 	sentryCaptureException(err, false, func() (*sentry.Hub, bool) {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -41,12 +41,15 @@ import (
 // It also carries over the sentry hub from the echo context to child context.
 // Make sure to call the returned function to finish the span.
 func StartSpanWithEcho(c echo.Context, operation string, spanOpts ...sentry.SpanOption) (context.Context, func()) {
-	var ctx context.Context
-	if hub := sentryecho.GetHubFromContext(c); hub != nil {
-		ctx = sentry.SetHubOnContext(c.Request().Context(), hub)
-	} else {
-		ctx = c.Request().Context()
+
+	ctx := c.Request().Context()
+
+	if sentry.GetHubFromContext(ctx) == nil {
+		if hub := sentryecho.GetHubFromContext(c); hub != nil {
+			ctx = sentry.SetHubOnContext(ctx, hub)
+		}
 	}
+
 	return startSpan(ctx, operation, 1, spanOpts...)
 }
 


### PR DESCRIPTION
## Description

- Enhance async task execution with `context.Context`
  - Execute a task with a **default pool** that is internally controlled if a pool name is given.
  - Trace and sample the async task **seamlessly, continuing from parent span**
     - (by `sentry.ContinueFromHeaders`) 
  - Capture an error **with the parent `sentry.Hub` and scoped `http.Request`** if it is encountered. 
     - (the local hub and request info are in advance carried over from `echo.Context` to `context.Context` through new `SetHubToContext` middleware)
  - Log an error **with the request id** if it is encountered. 
       - (the request id is set through new `RequestIDHandler` func)
