### PR TITLE
fix: 🐛 remove sentry profiling

### DIFF
--- a/cmd/bean/internal/project/commands/gopher/gopher.go.tpl
+++ b/cmd/bean/internal/project/commands/gopher/gopher.go.tpl
@@ -48,7 +48,6 @@ func initBean(isInitDB ...bool) *bean.Bean {
 				//BeforeSend:       msentry.CustomBeforeSend, // Default beforeSend function. You can initialize your own custom function.
 				AttachStacktrace: true,
 				TracesSampleRate: helpers.FloatInRange(bean.BeanConfig.Sentry.TracesSampleRate, 0.0, 1.0),
-				ProfilesSampleRate: helpers.FloatInRange(bean.BeanConfig.Sentry.ProfilesSampleRate, 0.0, 1.0),
 			}
 		}
 

--- a/cmd/bean/internal/project/commands/start.go.tpl
+++ b/cmd/bean/internal/project/commands/start.go.tpl
@@ -50,7 +50,6 @@ func start(cmd *cobra.Command, args []string) {
 			BeforeSend:       bean.DefaultBeforeSend, // Default beforeSend function. You can initialize your own custom function.
 			AttachStacktrace: true,
 			TracesSampleRate: helpers.FloatInRange(bean.BeanConfig.Sentry.TracesSampleRate, 0.0, 1.0),
-			ProfilesSampleRate: helpers.FloatInRange(bean.BeanConfig.Sentry.ProfilesSampleRate, 0.0, 1.0),
 		}
 
 		// Example of setting a global scope, if you want to set the scope per event,

--- a/cmd/bean/internal/project/env.json
+++ b/cmd/bean/internal/project/env.json
@@ -203,7 +203,6 @@
         "dsn": "",
         "timeout": "5s",
         "tracesSampleRate": 0.2,
-        "profilesSampleRate": 0.2,
         "skipTracesEndpoints": ["/ping","^/$","/metrics"]
     },
     "security": {

--- a/config/config.go
+++ b/config/config.go
@@ -139,7 +139,6 @@ type Sentry struct {
 	Dsn                 string
 	Timeout             time.Duration
 	TracesSampleRate    float64
-	ProfilesSampleRate  float64
 	SkipTracesEndpoints []string
 	ClientOptions       *sentry.ClientOptions
 	ConfigureScope      func(scope *sentry.Scope)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/retail-ai-inc/bean/v2
 
-go 1.22.7
-toolchain go1.23.4
+go 1.23.4
 
 require (
 	github.com/alphadose/haxmap v1.4.1


### PR DESCRIPTION
## Description
- `ProfilesSampleRate` has been removed since [sentry 0.31.0](https://github.com/getsentry/sentry-go/releases/tag/v0.31.0)