### PR TITLE
add errorMsg field to testCase responses

### DIFF
--- a/test/utils.go
+++ b/test/utils.go
@@ -77,6 +77,7 @@ func createHttpClient(withRetry bool) *resty.Client {
 type RespBody struct {
 	ErrorCode string                 `json:"errorCode,omitempty"`
 	Data      map[string]interface{} `json:"data,omitempty"`
+	ErrorMsg  string                 `json:"errorMsg,omitempty"`
 }
 
 func UnmarshalRespBody(t *testing.T, respBody []byte) RespBody {


### PR DESCRIPTION
# PR Template

## Description

Add `errorMsg` field to the `RespBody` struct for decoding responses.

Fixes # (issue)

## Summary of Changes:

It will help decode the errorMsg field that is common in bean responses.