### PR TITLE
fix empty response body issue

### DIFF
--- a/internal/middleware/access_log.go
+++ b/internal/middleware/access_log.go
@@ -107,7 +107,7 @@ var (
 	}
 )
 
-func logErrorInDump(hdlrErr error, resBody *bytes.Buffer, writer *bodyDumpResponseWriter) error {
+func logErrorInDump(hdlrErr error, resBody *bytes.Buffer, writer *bodyDumpResponseWriter) {
 	var ae *berror.APIError
 	if errors.As(hdlrErr, &ae) && resBody.Len() == 0 {
 		// helps capture the APIError in dump logs.
@@ -119,7 +119,6 @@ func logErrorInDump(hdlrErr error, resBody *bytes.Buffer, writer *bodyDumpRespon
 		resBody.Write(errorJSON)          // Write to logger's buffer
 		writer.Status = ae.HTTPStatusCode // Set status for logging
 	}
-	return nil
 }
 
 // AccessLoggerWithConfig returns a Logger middleware with config.

--- a/internal/middleware/access_log.go
+++ b/internal/middleware/access_log.go
@@ -35,6 +35,8 @@ import (
 	"sync"
 	"time"
 
+	berror "github.com/retail-ai-inc/bean/v2/error"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/color"
@@ -105,6 +107,21 @@ var (
 	}
 )
 
+func logErrorInDump(hdlrErr error, resBody *bytes.Buffer, writer *bodyDumpResponseWriter) error {
+	var ae *berror.APIError
+	if errors.As(hdlrErr, &ae) && resBody.Len() == 0 {
+		// helps capture the APIError in dump logs.
+		errorResp := berror.ErrorResp{
+			ErrorCode: ae.GlobalErrCode,
+			ErrorMsg:  ae.Error(),
+		}
+		errorJSON, _ := json.Marshal(errorResp)
+		resBody.Write(errorJSON)          // Write to logger's buffer
+		writer.Status = ae.HTTPStatusCode // Set status for logging
+	}
+	return nil
+}
+
 // AccessLoggerWithConfig returns a Logger middleware with config.
 func AccessLoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 	// Defaults
@@ -167,6 +184,10 @@ func AccessLoggerWithConfig(config LoggerConfig) echo.MiddlewareFunc {
 			res := c.Response()
 			start := time.Now()
 			hdlrErr := next(c)
+			if hdlrErr != nil {
+				logErrorInDump(hdlrErr, resBody, writer)
+			}
+
 			stop := time.Now()
 			buf := config.pool.Get().(*bytes.Buffer)
 			buf.Reset()


### PR DESCRIPTION
## Description

Resolve 2 issues
1. empty response_body in dump logs
2. duplicate log entry for errors raised via berror.NewApiError.

Fixes # (issue)

## Summary of Changes:

#### **Fix 1**  
- added logErrorInDump in accesslog middleware

#### **Fix 2**  
- updated APIErrorHandlerFunc

## How Has This Been Tested?

Using gulab and ohagi apis for testing. 
Attaching before and after screenshots.

<img width="1897" height="127" alt="before_empty_response_body(issue 1)" src="https://github.com/user-attachments/assets/8e62149d-7014-4f4e-8e16-68e55ddb7483" />


<img width="1905" height="155" alt="before_dual_logging(issue 2)" src="https://github.com/user-attachments/assets/f913e208-b082-4841-b4b5-76eab84536fd" />


<img width="1888" height="241" alt="after_fix" src="https://github.com/user-attachments/assets/98b7e26d-1693-4353-b852-f033d92a8496" />

