### PR TITLE
feat(mask): Mask sensitive fields for xml body  

### DIFF
--- a/log/mask.go
+++ b/log/mask.go
@@ -1,7 +1,10 @@
 package log
 
 import (
+	"bytes"
 	"encoding/json"
+	"encoding/xml"
+	"io"
 )
 
 type Processor interface {
@@ -53,19 +56,24 @@ func (p *MaskProcessor) maskValue(val interface{}) interface{} {
 		return v
 
 	case string:
-		if !looksLikeJSON(v) {
-			return v
+		if looksLikeJSON(v) {
+			var decoded interface{}
+			if err := json.Unmarshal([]byte(v), &decoded); err != nil {
+				return v
+			}
+			masked := p.maskValue(decoded)
+			b, err := json.Marshal(masked)
+			if err != nil {
+				return v
+			}
+			return string(b)
 		}
-		var decoded interface{}
-		if err := json.Unmarshal([]byte(v), &decoded); err != nil {
-			return v
+		if looksLikeXML(v) {
+			if out, ok := p.maskXMLBytes([]byte(v)); ok {
+				return string(out)
+			}
 		}
-		masked := p.maskValue(decoded)
-		b, err := json.Marshal(masked)
-		if err != nil {
-			return v
-		}
-		return string(b)
+		return v
 
 	case json.RawMessage:
 		b, ok := p.maskJSONBytes([]byte(v))
@@ -109,4 +117,78 @@ func looksLikeJSON(s string) bool {
 		return true
 	}
 	return false
+}
+
+// looksLikeXML reports whether the first non-whitespace byte is '<', which
+// covers XML declarations, SOAP envelopes and plain XML documents.
+func looksLikeXML(s string) bool {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '<':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func (p *MaskProcessor) maskXMLBytes(in []byte) ([]byte, bool) {
+	dec := xml.NewDecoder(bytes.NewReader(in))
+	dec.Strict = false
+
+	var spans [][2]int
+	depth := 0
+	maskDepth := 0 // 0 = not masking; >0 = inside a masked subtree rooted at this depth
+
+	for {
+		off0 := dec.InputOffset()
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, false
+		}
+		off1 := dec.InputOffset()
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			depth++
+			if maskDepth == 0 {
+				if _, ok := p.fields[t.Name.Local]; ok {
+					maskDepth = depth
+				}
+			}
+		case xml.EndElement:
+			if maskDepth > 0 && depth == maskDepth {
+				maskDepth = 0
+			}
+			depth--
+		case xml.CharData:
+			if maskDepth > 0 && len(bytes.TrimSpace([]byte(t))) > 0 {
+				spans = append(spans, [2]int{int(off0), int(off1)})
+			}
+		}
+	}
+
+	if len(spans) == 0 {
+		return in, true
+	}
+
+	var out bytes.Buffer
+	prev := 0
+	for _, s := range spans {
+		if s[0] < prev || s[1] > len(in) {
+			continue
+		}
+		out.Write(in[prev:s[0]])
+		out.WriteString("****")
+		prev = s[1]
+	}
+	out.Write(in[prev:])
+
+	return out.Bytes(), true
 }

--- a/log/mask.go
+++ b/log/mask.go
@@ -1,11 +1,16 @@
 package log
 
 import (
-	"bytes"
 	"encoding/json"
-	"encoding/xml"
-	"io"
+	"fmt"
+	"regexp"
+	"strings"
 )
+
+// utf8BOM is the UTF-8 byte order mark. We only support UTF-8 payloads; a
+// leading BOM is still valid UTF-8 but would defeat the JSON/XML sniffing
+// below, so we strip it before detection and masking.
+const utf8BOM = "\uFEFF"
 
 type Processor interface {
 	Process(entry Entry) Entry
@@ -13,15 +18,24 @@ type Processor interface {
 
 type MaskProcessor struct {
 	fields map[string]struct{}
+	xmlRes []*regexp.Regexp
 }
 
 func NewMaskProcessor(fields []string) *MaskProcessor {
 	fm := make(map[string]struct{}, len(fields))
+	xmlRes := make([]*regexp.Regexp, 0, len(fields))
 	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
 		fm[f] = struct{}{}
+
+		quoted := regexp.QuoteMeta(f)
+		xmlRes = append(xmlRes, regexp.MustCompile(fmt.Sprintf(`(?s)(<(?:\w+:)?%s\b[^>]*>)(.*?)(</(?:\w+:)?%s>)`, quoted, quoted)))
 	}
 
-	return &MaskProcessor{fields: fm}
+	return &MaskProcessor{fields: fm, xmlRes: xmlRes}
 }
 
 func (p *MaskProcessor) Process(entry Entry) Entry {
@@ -56,9 +70,14 @@ func (p *MaskProcessor) maskValue(val interface{}) interface{} {
 		return v
 
 	case string:
-		if looksLikeJSON(v) {
+		s := strings.TrimPrefix(v, utf8BOM)
+		if !p.containsAnyField(s) {
+			return v
+		}
+
+		if looksLikeJSON(s) {
 			var decoded interface{}
-			if err := json.Unmarshal([]byte(v), &decoded); err != nil {
+			if err := json.Unmarshal([]byte(s), &decoded); err != nil {
 				return v
 			}
 			masked := p.maskValue(decoded)
@@ -68,10 +87,12 @@ func (p *MaskProcessor) maskValue(val interface{}) interface{} {
 			}
 			return string(b)
 		}
-		if looksLikeXML(v) {
-			if out, ok := p.maskXMLBytes([]byte(v)); ok {
-				return string(out)
+
+		if looksLikeXMLPayload(s) {
+			if out, masked := p.maskXMLString(s); masked {
+				return out
 			}
+			return "****"
 		}
 		return v
 
@@ -83,11 +104,26 @@ func (p *MaskProcessor) maskValue(val interface{}) interface{} {
 		return json.RawMessage(b)
 
 	case []byte:
-		b, ok := p.maskJSONBytes(v)
-		if !ok {
+		s := strings.TrimPrefix(string(v), utf8BOM)
+		if !p.containsAnyField(s) {
 			return string(v)
 		}
-		return json.RawMessage(b)
+
+		if looksLikeJSON(s) {
+			if b, ok := p.maskJSONBytes([]byte(s)); ok {
+				return json.RawMessage(b)
+			}
+			return string(v)
+		}
+
+		if looksLikeXMLPayload(s) {
+			if out, masked := p.maskXMLString(s); masked {
+				return []byte(out)
+			}
+			// Fail closed for truncated/malformed XML carrying a sensitive field.
+			return []byte("****")
+		}
+		return string(v)
 
 	default:
 		return v
@@ -119,76 +155,46 @@ func looksLikeJSON(s string) bool {
 	return false
 }
 
-// looksLikeXML reports whether the first non-whitespace byte is '<', which
-// covers XML declarations, SOAP envelopes and plain XML documents.
-func looksLikeXML(s string) bool {
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case ' ', '\t', '\n', '\r':
-			continue
-		case '<':
+// containsAnyField reports whether any configured mask field name appears as a
+// substring of s.
+func (p *MaskProcessor) containsAnyField(s string) bool {
+	for f := range p.fields {
+		if f != "" && strings.Contains(s, f) {
 			return true
-		default:
-			return false
 		}
 	}
 	return false
 }
 
+// looksLikeXMLPayload reports whether s contains XML markup. It intentionally
+// tolerates surrounding log noise such as HTTP status lines and headers.
+func looksLikeXMLPayload(s string) bool {
+	return strings.IndexByte(s, '<') >= 0
+}
+
 func (p *MaskProcessor) maskXMLBytes(in []byte) ([]byte, bool) {
-	dec := xml.NewDecoder(bytes.NewReader(in))
-	dec.Strict = false
+	out, masked := p.maskXMLString(string(in))
+	if !masked {
+		return in, !p.containsAnyField(string(in))
+	}
+	return []byte(out), true
+}
 
-	var spans [][2]int
-	depth := 0
-	maskDepth := 0 // 0 = not masking; >0 = inside a masked subtree rooted at this depth
+// maskXMLString redacts configured XML/SOAP element values without requiring the
+// whole input to be a valid XML document, matching the logger used by emoney.
+func (p *MaskProcessor) maskXMLString(s string) (string, bool) {
+	if s == "" || !looksLikeXMLPayload(s) || !p.containsAnyField(s) {
+		return s, false
+	}
 
-	for {
-		off0 := dec.InputOffset()
-		tok, err := dec.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, false
-		}
-		off1 := dec.InputOffset()
-
-		switch t := tok.(type) {
-		case xml.StartElement:
-			depth++
-			if maskDepth == 0 {
-				if _, ok := p.fields[t.Name.Local]; ok {
-					maskDepth = depth
-				}
-			}
-		case xml.EndElement:
-			if maskDepth > 0 && depth == maskDepth {
-				maskDepth = 0
-			}
-			depth--
-		case xml.CharData:
-			if maskDepth > 0 && len(bytes.TrimSpace([]byte(t))) > 0 {
-				spans = append(spans, [2]int{int(off0), int(off1)})
-			}
+	masked := false
+	for _, re := range p.xmlRes {
+		next := re.ReplaceAllString(s, "${1}****${3}")
+		if next != s {
+			masked = true
+			s = next
 		}
 	}
 
-	if len(spans) == 0 {
-		return in, true
-	}
-
-	var out bytes.Buffer
-	prev := 0
-	for _, s := range spans {
-		if s[0] < prev || s[1] > len(in) {
-			continue
-		}
-		out.Write(in[prev:s[0]])
-		out.WriteString("****")
-		prev = s[1]
-	}
-	out.Write(in[prev:])
-
-	return out.Bytes(), true
+	return s, masked
 }

--- a/log/mask_test.go
+++ b/log/mask_test.go
@@ -378,10 +378,23 @@ func TestMaskProcessor_maskXMLBytes(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:   "mask_nested_descendants_of_masked_container",
+			name:   "mask_element_contents_without_parsing_full_document",
 			fields: []string{"card"},
 			in:     `<req><card><number>4111</number><cvv>123</cvv></card></req>`,
-			want:   `<req><card><number>****</number><cvv>****</cvv></card></req>`,
+			want:   `<req><card>****</card></req>`,
+			wantOK: true,
+		},
+		{
+			name:   "mask_xml_inside_http_dump",
+			fields: []string{"cardNo", "pinCode"},
+			in: `HTTP/1.1 200 OK
+Content-Type: text/xml
+
+<Deposit><cardNo>4111111111111111</cardNo><pinCode>1234</pinCode><amount>100</amount></Deposit>`,
+			want: `HTTP/1.1 200 OK
+Content-Type: text/xml
+
+<Deposit><cardNo>****</cardNo><pinCode>****</pinCode><amount>100</amount></Deposit>`,
 			wantOK: true,
 		},
 		{
@@ -416,6 +429,48 @@ func TestMaskProcessor_maskXMLBytes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMaskProcessor_Process_XMLFailClosedAndBOM(t *testing.T) {
+	t.Run("truncated_xml_with_sensitive_field_is_fully_redacted", func(t *testing.T) {
+		p := NewMaskProcessor([]string{"cardNo"})
+		entry := Entry{
+			Fields: map[string]interface{}{
+				// Truncated/unparseable XML that still carries the card number.
+				"request_body": `<Deposit><cardNo>4111111111111111</cardN`,
+			},
+		}
+
+		got := p.Process(entry)
+
+		assert.Equal(t, "****", got.Fields["request_body"])
+	})
+
+	t.Run("unparseable_xml_without_sensitive_field_is_kept", func(t *testing.T) {
+		p := NewMaskProcessor([]string{"cardNo"})
+		entry := Entry{
+			Fields: map[string]interface{}{
+				"request_body": `<note>hello <b`,
+			},
+		}
+
+		got := p.Process(entry)
+
+		assert.Equal(t, `<note>hello <b`, got.Fields["request_body"])
+	})
+
+	t.Run("utf8_bom_prefixed_xml_is_masked", func(t *testing.T) {
+		p := NewMaskProcessor([]string{"cardNo"})
+		entry := Entry{
+			Fields: map[string]interface{}{
+				"request_body": "\uFEFF<Deposit><cardNo>4111111111111111</cardNo></Deposit>",
+			},
+		}
+
+		got := p.Process(entry)
+
+		assert.Equal(t, `<Deposit><cardNo>****</cardNo></Deposit>`, got.Fields["request_body"])
+	})
 }
 
 func TestMaskProcessor_Process_XMLStringField(t *testing.T) {

--- a/log/mask_test.go
+++ b/log/mask_test.go
@@ -1,7 +1,10 @@
 package log
 
 import (
+	"bytes"
 	"encoding/json"
+	"encoding/xml"
+	"io"
 	"testing"
 	"time"
 
@@ -551,5 +554,105 @@ func TestMaskProcessor_maskValue_EdgeCases(t *testing.T) {
 
 		// Should return the original malformed JSON
 		assert.Equal(t, malformedJSON, result.Fields["data"])
+	})
+}
+
+// benchSOAP is a representative SOAP/XML payload carrying several sensitive
+// elements, used by the masking benchmarks below.
+var benchSOAP = []byte(`<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">` +
+	`<soapenv:Header/>` +
+	`<soapenv:Body>` +
+	`<ns:Deposit xmlns:ns="urn:vd">` +
+	`<ns:cardNo>4111111111111111</ns:cardNo>` +
+	`<ns:pinCode>1234</ns:pinCode>` +
+	`<ns:accessKey>super-secret-access-key-value</ns:accessKey>` +
+	`<ns:amount>1500</ns:amount>` +
+	`<ns:currency>JPY</ns:currency>` +
+	`<ns:merchant>SUPAY-DEMO-MERCHANT</ns:merchant>` +
+	`</ns:Deposit>` +
+	`</soapenv:Body>` +
+	`</soapenv:Envelope>`)
+
+// maskXMLViaDecoder reproduces the previous encoding/xml streaming masker. It
+// exists only as a performance baseline for BenchmarkMaskSOAP and is not used
+// by production code.
+func (p *MaskProcessor) maskXMLViaDecoder(in []byte) ([]byte, bool) {
+	dec := xml.NewDecoder(bytes.NewReader(in))
+	dec.Strict = false
+
+	var spans [][2]int
+	depth := 0
+	maskDepth := 0 // 0 = not masking; >0 = inside a masked subtree rooted at this depth
+
+	for {
+		off0 := dec.InputOffset()
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, false
+		}
+		off1 := dec.InputOffset()
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			depth++
+			if maskDepth == 0 {
+				if _, ok := p.fields[t.Name.Local]; ok {
+					maskDepth = depth
+				}
+			}
+		case xml.EndElement:
+			if maskDepth > 0 && depth == maskDepth {
+				maskDepth = 0
+			}
+			depth--
+		case xml.CharData:
+			if maskDepth > 0 && len(bytes.TrimSpace([]byte(t))) > 0 {
+				spans = append(spans, [2]int{int(off0), int(off1)})
+			}
+		}
+	}
+
+	if len(spans) == 0 {
+		return in, true
+	}
+
+	var out bytes.Buffer
+	prev := 0
+	for _, s := range spans {
+		if s[0] < prev || s[1] > len(in) {
+			continue
+		}
+		out.Write(in[prev:s[0]])
+		out.WriteString("****")
+		prev = s[1]
+	}
+	out.Write(in[prev:])
+
+	return out.Bytes(), true
+}
+
+// BenchmarkMaskSOAP compares the current regexp-based masker against the
+// previous encoding/xml streaming masker on the same SOAP payload.
+//
+//	go test ./log -bench=BenchmarkMaskSOAP -benchmem -benchtime=3s
+func BenchmarkMaskSOAP(b *testing.B) {
+	p := NewMaskProcessor([]string{"cardNo", "pinCode", "accessKey"})
+	s := string(benchSOAP)
+
+	b.Run("regex", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = p.maskXMLString(s)
+		}
+	})
+
+	b.Run("xml_decoder", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, _ = p.maskXMLViaDecoder(benchSOAP)
+		}
 	})
 }

--- a/log/mask_test.go
+++ b/log/mask_test.go
@@ -355,6 +355,83 @@ func TestMaskProcessor_Process(t *testing.T) {
 	}
 }
 
+func TestMaskProcessor_maskXMLBytes(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []string
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "mask_leaf_element_text",
+			fields: []string{"cardNumber"},
+			in:     `<payment><cardNumber>4111111111111111</cardNumber><amount>100</amount></payment>`,
+			want:   `<payment><cardNumber>****</cardNumber><amount>100</amount></payment>`,
+			wantOK: true,
+		},
+		{
+			name:   "mask_namespaced_soap_element_by_local_name",
+			fields: []string{"cardNumber"},
+			in:     `<soapenv:Envelope><soapenv:Body><ns:cardNumber>4111111111111111</ns:cardNumber></soapenv:Body></soapenv:Envelope>`,
+			want:   `<soapenv:Envelope><soapenv:Body><ns:cardNumber>****</ns:cardNumber></soapenv:Body></soapenv:Envelope>`,
+			wantOK: true,
+		},
+		{
+			name:   "mask_nested_descendants_of_masked_container",
+			fields: []string{"card"},
+			in:     `<req><card><number>4111</number><cvv>123</cvv></card></req>`,
+			want:   `<req><card><number>****</number><cvv>****</cvv></card></req>`,
+			wantOK: true,
+		},
+		{
+			name:   "preserve_whitespace_indentation",
+			fields: []string{"pin"},
+			in:     "<root>\n  <pin>9999</pin>\n  <ok>yes</ok>\n</root>",
+			want:   "<root>\n  <pin>****</pin>\n  <ok>yes</ok>\n</root>",
+			wantOK: true,
+		},
+		{
+			name:   "no_matching_fields_returns_input_unchanged",
+			fields: []string{"missing"},
+			in:     `<root><a>1</a></root>`,
+			want:   `<root><a>1</a></root>`,
+			wantOK: true,
+		},
+		{
+			name:   "incomplete_xml_not_masked",
+			fields: []string{"pin"},
+			in:     `<root><pin`,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewMaskProcessor(tt.fields)
+			out, ok := p.maskXMLBytes([]byte(tt.in))
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, string(out))
+			}
+		})
+	}
+}
+
+func TestMaskProcessor_Process_XMLStringField(t *testing.T) {
+	p := NewMaskProcessor([]string{"cardNumber", "pinCode"})
+	entry := Entry{
+		Fields: map[string]interface{}{
+			"request_body": `<soapenv:Envelope><soapenv:Body><Deposit><cardNumber>4111111111111111</cardNumber><pinCode>1234</pinCode><amount>500</amount></Deposit></soapenv:Body></soapenv:Envelope>`,
+		},
+	}
+
+	got := p.Process(entry)
+
+	want := `<soapenv:Envelope><soapenv:Body><Deposit><cardNumber>****</cardNumber><pinCode>****</pinCode><amount>500</amount></Deposit></soapenv:Body></soapenv:Envelope>`
+	assert.Equal(t, want, got.Fields["request_body"])
+}
+
 func TestMaskProcessor_Process_PreserveMetadata(t *testing.T) {
 	now := time.Now()
 	trace := Trace{


### PR DESCRIPTION
# PR Template

## Description

Mask sensitive fields for xml body  

Fixes # (issue)

## Summary of Changes:

#### **Added:**  
- Something A
- Something B

#### **Modified:**  
- Modified: `log/mask.go`
- Modified: `log/mask_test.go`

#### **Deleted:**  
- Something A
- Something B

## Impact

Please describe any impact of this change. This can be a positive or negative impact.

## Performance

Please describe any relevant performance impact of this change. This can be a positive or negative impact. How did you characterize/test the performance impact?
```
go test ./log -bench=BenchmarkMaskSOAP -benchmem -benchtime=2s
goos: windows
goarch: amd64
pkg: github.com/retail-ai-inc/bean/v2/log   
cpu: Intel(R) Core(TM) i5-9500 CPU @ 3.00GHz
BenchmarkMaskSOAP/regex-6                 202473             11863 ns/op            4275 B/op         17 allocs/op
BenchmarkMaskSOAP/xml_decoder-6           177465             14590 ns/op            4848 B/op         86 allocs/op
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
